### PR TITLE
add some comment about production usage, remove unnecessary `initialize` function for previous version.

### DIFF
--- a/test/contracts/Greeter.sol
+++ b/test/contracts/Greeter.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.8.20;
 contract Greeter {
     string public greeting;
 
+    // For production usage, you may want to add `initializer` from the openzepplin `Initializable` contract.
     function initialize(string memory _greeting) public {
         greeting = _greeting;
     }

--- a/test/contracts/GreeterProxiable.sol
+++ b/test/contracts/GreeterProxiable.sol
@@ -8,6 +8,7 @@ import {Proxiable} from "./Proxiable.sol";
 contract GreeterProxiable is Proxiable {
     string public greeting;
 
+    // For production usage, you may want to add `initializer` from the openzepplin `Initializable` contract.
     function initialize(string memory _greeting) public {
         greeting = _greeting;
     }

--- a/test/contracts/GreeterV2.sol
+++ b/test/contracts/GreeterV2.sol
@@ -7,10 +7,8 @@ pragma solidity ^0.8.20;
 contract GreeterV2 {
     string public greeting;
 
-    function initialize(string memory _greeting) public {
-        greeting = _greeting;
-    }
 
+    // For production usage, you may want to add `reinitializer(2)` from the openzepplin `Initializable` contract for the 2nd initialization function.
     function resetGreeting() public {
         greeting = "resetted";
     }

--- a/test/contracts/GreeterV2Proxiable.sol
+++ b/test/contracts/GreeterV2Proxiable.sol
@@ -9,10 +9,7 @@ import {Proxiable} from "./Proxiable.sol";
 contract GreeterV2Proxiable is Proxiable {
     string public greeting;
 
-    function initialize(string memory _greeting) public {
-        greeting = _greeting;
-    }
-
+    // For production usage, you may want to add `reinitializer(2)` from the openzepplin `Initializable` contract for the 2nd initialization function.
     function resetGreeting() public {
         greeting = "resetted";
     }


### PR DESCRIPTION
For production usage, one may need to add `initializer`/`reinitializer` modifiers to the initialization function.

And the 2nd version of the contract is ok to remove the initialization function of the 1st version, only the storage layout needs to be consistent.