### PR TITLE
Use fully qualified contract names for CLI, support artifact paths

### DIFF
--- a/src/Upgrades.sol
+++ b/src/Upgrades.sol
@@ -448,8 +448,8 @@ library Upgrades {
         string memory contractName,
         Options memory opts,
         bool requireReference
-    ) private view returns (string[] memory) {
-        string memory outDir = Utils.getOutDirWithDefaults(opts.outDir);
+    ) private returns (string[] memory) {
+        string memory outDir = Utils.getOutDir();
 
         string[] memory inputBuilder = new string[](255);
 

--- a/src/Upgrades.sol
+++ b/src/Upgrades.sol
@@ -14,7 +14,8 @@ import {Vm} from "forge-std/Vm.sol";
 import {console} from "forge-std/console.sol";
 import {strings} from "solidity-stringutils/strings.sol";
 
-import {Versions} from "./Versions.sol";
+import {Versions} from "./internal/Versions.sol";
+import {Utils} from "./internal/Utils.sol";
 
 struct Options {
     /**
@@ -58,7 +59,7 @@ library Upgrades {
     /**
      * @dev Deploys a UUPS proxy using the given contract as the implementation.
      *
-     * @param contractName Name of the contract to use as the implementation, e.g. "MyContract.sol" or "MyContract.sol:MyContract"
+     * @param contractName Name of the contract to use as the implementation, e.g. "MyContract.sol" or "MyContract.sol:MyContract" or artifact path relative to the project root directory
      * @param initializerData Encoded call data of the initializer function to call during creation of the proxy, or empty if no initialization is required
      * @param opts Common options
      * @return Proxy address
@@ -75,7 +76,7 @@ library Upgrades {
     /**
      * @dev Deploys a UUPS proxy using the given contract as the implementation.
      *
-     * @param contractName Name of the contract to use as the implementation, e.g. "MyContract.sol" or "MyContract.sol:MyContract"
+     * @param contractName Name of the contract to use as the implementation, e.g. "MyContract.sol" or "MyContract.sol:MyContract" or artifact path relative to the project root directory
      * @param initializerData Encoded call data of the initializer function to call during creation of the proxy, or empty if no initialization is required
      * @return Proxy address
      */
@@ -87,7 +88,7 @@ library Upgrades {
     /**
      * @dev Deploys a transparent proxy using the given contract as the implementation.
      *
-     * @param contractName Name of the contract to use as the implementation, e.g. "MyContract.sol" or "MyContract.sol:MyContract"
+     * @param contractName Name of the contract to use as the implementation, e.g. "MyContract.sol" or "MyContract.sol:MyContract" or artifact path relative to the project root directory
      * @param initialOwner Address to set as the owner of the ProxyAdmin contract which gets deployed by the proxy
      * @param initializerData Encoded call data of the initializer function to call during creation of the proxy, or empty if no initialization is required
      * @param opts Common options
@@ -106,7 +107,7 @@ library Upgrades {
     /**
      * @dev Deploys a transparent proxy using the given contract as the implementation.
      *
-     * @param contractName Name of the contract to use as the implementation, e.g. "MyContract.sol" or "MyContract.sol:MyContract"
+     * @param contractName Name of the contract to use as the implementation, e.g. "MyContract.sol" or "MyContract.sol:MyContract" or artifact path relative to the project root directory
      * @param initialOwner Address to set as the owner of the ProxyAdmin contract which gets deployed by the proxy
      * @param initializerData Encoded call data of the initializer function to call during creation of the proxy, or empty if no initialization is required
      * @return Proxy address
@@ -126,7 +127,7 @@ library Upgrades {
      * Requires that either the `referenceContract` option is set, or the new implementation contract has a `@custom:oz-upgrades-from <reference>` annotation.
      *
      * @param proxy Address of the proxy to upgrade
-     * @param contractName Name of the new implementation contract to upgrade to, e.g. "MyContract.sol" or "MyContract.sol:MyContract"
+     * @param contractName Name of the new implementation contract to upgrade to, e.g. "MyContract.sol" or "MyContract.sol:MyContract" or artifact path relative to the project root directory
      * @param data Encoded call data of an arbitrary function to call during the upgrade process, or empty if no function needs to be called during the upgrade
      * @param opts Common options
      */
@@ -151,7 +152,7 @@ library Upgrades {
      * Requires that either the `referenceContract` option is set, or the new implementation contract has a `@custom:oz-upgrades-from <reference>` annotation.
      *
      * @param proxy Address of the proxy to upgrade
-     * @param contractName Name of the new implementation contract to upgrade to, e.g. "MyContract.sol" or "MyContract.sol:MyContract"
+     * @param contractName Name of the new implementation contract to upgrade to, e.g. "MyContract.sol" or "MyContract.sol:MyContract" or artifact path relative to the project root directory
      * @param data Encoded call data of an arbitrary function to call during the upgrade process, or empty if no function needs to be called during the upgrade
      */
     function upgradeProxy(address proxy, string memory contractName, bytes memory data) internal {
@@ -170,7 +171,7 @@ library Upgrades {
      * Use this if you encounter `OwnableUnauthorizedAccount` errors in your tests.
      *
      * @param proxy Address of the proxy to upgrade
-     * @param contractName Name of the new implementation contract to upgrade to, e.g. "MyContract.sol" or "MyContract.sol:MyContract"
+     * @param contractName Name of the new implementation contract to upgrade to, e.g. "MyContract.sol" or "MyContract.sol:MyContract" or artifact path relative to the project root directory
      * @param data Encoded call data of an arbitrary function to call during the upgrade process, or empty if no function needs to be called during the upgrade
      * @param opts Common options
      * @param tryCaller Address to use as the caller of the upgrade function. This should be the address that owns the proxy or its ProxyAdmin.
@@ -196,7 +197,7 @@ library Upgrades {
      * Use this if you encounter `OwnableUnauthorizedAccount` errors in your tests.
      *
      * @param proxy Address of the proxy to upgrade
-     * @param contractName Name of the new implementation contract to upgrade to, e.g. "MyContract.sol" or "MyContract.sol:MyContract"
+     * @param contractName Name of the new implementation contract to upgrade to, e.g. "MyContract.sol" or "MyContract.sol:MyContract" or artifact path relative to the project root directory
      * @param data Encoded call data of an arbitrary function to call during the upgrade process, or empty if no function needs to be called during the upgrade
      * @param tryCaller Address to use as the caller of the upgrade function. This should be the address that owns the proxy or its ProxyAdmin.
      */
@@ -213,7 +214,7 @@ library Upgrades {
     /**
      * @dev Deploys an upgradeable beacon using the given contract as the implementation.
      *
-     * @param contractName Name of the contract to use as the implementation, e.g. "MyContract.sol" or "MyContract.sol:MyContract"
+     * @param contractName Name of the contract to use as the implementation, e.g. "MyContract.sol" or "MyContract.sol:MyContract" or artifact path relative to the project root directory
      * @param initialOwner Address to set as the owner of the UpgradeableBeacon contract which gets deployed
      * @param opts Common options
      * @return Beacon address
@@ -230,7 +231,7 @@ library Upgrades {
     /**
      * @dev Deploys an upgradeable beacon using the given contract as the implementation.
      *
-     * @param contractName Name of the contract to use as the implementation, e.g. "MyContract.sol" or "MyContract.sol:MyContract"
+     * @param contractName Name of the contract to use as the implementation, e.g. "MyContract.sol" or "MyContract.sol:MyContract" or artifact path relative to the project root directory
      * @param initialOwner Address to set as the owner of the UpgradeableBeacon contract which gets deployed
      * @return Beacon address
      */
@@ -245,7 +246,7 @@ library Upgrades {
      * Requires that either the `referenceContract` option is set, or the new implementation contract has a `@custom:oz-upgrades-from <reference>` annotation.
      *
      * @param beacon Address of the beacon to upgrade
-     * @param contractName Name of the new implementation contract to upgrade to, e.g. "MyContract.sol" or "MyContract.sol:MyContract"
+     * @param contractName Name of the new implementation contract to upgrade to, e.g. "MyContract.sol" or "MyContract.sol:MyContract" or artifact path relative to the project root directory
      * @param opts Common options
      */
     function upgradeBeacon(address beacon, string memory contractName, Options memory opts) internal {
@@ -259,7 +260,7 @@ library Upgrades {
      * Requires that either the `referenceContract` option is set, or the new implementation contract has a `@custom:oz-upgrades-from <reference>` annotation.
      *
      * @param beacon Address of the beacon to upgrade
-     * @param contractName Name of the new implementation contract to upgrade to, e.g. "MyContract.sol" or "MyContract.sol:MyContract"
+     * @param contractName Name of the new implementation contract to upgrade to, e.g. "MyContract.sol" or "MyContract.sol:MyContract" or artifact path relative to the project root directory
      */
     function upgradeBeacon(address beacon, string memory contractName) internal {
         Options memory opts;
@@ -277,7 +278,7 @@ library Upgrades {
      * Use this if you encounter `OwnableUnauthorizedAccount` errors in your tests.
      *
      * @param beacon Address of the beacon to upgrade
-     * @param contractName Name of the new implementation contract to upgrade to, e.g. "MyContract.sol" or "MyContract.sol:MyContract"
+     * @param contractName Name of the new implementation contract to upgrade to, e.g. "MyContract.sol" or "MyContract.sol:MyContract" or artifact path relative to the project root directory
      * @param opts Common options
      * @param tryCaller Address to use as the caller of the upgrade function. This should be the address that owns the beacon.
      */
@@ -301,7 +302,7 @@ library Upgrades {
      * Use this if you encounter `OwnableUnauthorizedAccount` errors in your tests.
      *
      * @param beacon Address of the beacon to upgrade
-     * @param contractName Name of the new implementation contract to upgrade to, e.g. "MyContract.sol" or "MyContract.sol:MyContract"
+     * @param contractName Name of the new implementation contract to upgrade to, e.g. "MyContract.sol" or "MyContract.sol:MyContract" or artifact path relative to the project root directory
      * @param tryCaller Address to use as the caller of the upgrade function. This should be the address that owns the beacon.
      */
     function upgradeBeacon(address beacon, string memory contractName, address tryCaller) internal tryPrank(tryCaller) {
@@ -323,7 +324,7 @@ library Upgrades {
     /**
      * @dev Validates an implementation contract, but does not deploy it.
      *
-     * @param contractName Name of the contract to validate, e.g. "MyContract.sol" or "MyContract.sol:MyContract"
+     * @param contractName Name of the contract to validate, e.g. "MyContract.sol" or "MyContract.sol:MyContract" or artifact path relative to the project root directory
      * @param opts Common options
      */
     function validateImplementation(string memory contractName, Options memory opts) internal {
@@ -333,7 +334,7 @@ library Upgrades {
     /**
      * @dev Validates and deploys an implementation contract, and returns its address.
      *
-     * @param contractName Name of the contract to deploy, e.g. "MyContract.sol" or "MyContract.sol:MyContract"
+     * @param contractName Name of the contract to deploy, e.g. "MyContract.sol" or "MyContract.sol:MyContract" or artifact path relative to the project root directory
      * @param opts Common options
      * @return Address of the implementation contract
      */
@@ -347,7 +348,7 @@ library Upgrades {
      *
      * Requires that either the `referenceContract` option is set, or the contract has a `@custom:oz-upgrades-from <reference>` annotation.
      *
-     * @param contractName Name of the contract to validate, e.g. "MyContract.sol" or "MyContract.sol:MyContract"
+     * @param contractName Name of the contract to validate, e.g. "MyContract.sol" or "MyContract.sol:MyContract" or artifact path relative to the project root directory
      * @param opts Common options
      */
     function validateUpgrade(string memory contractName, Options memory opts) internal {
@@ -362,7 +363,7 @@ library Upgrades {
      *
      * Use this method to prepare an upgrade to be run from an admin address you do not control directly or cannot use from your deployment environment.
      *
-     * @param contractName Name of the contract to deploy, e.g. "MyContract.sol" or "MyContract.sol:MyContract"
+     * @param contractName Name of the contract to deploy, e.g. "MyContract.sol" or "MyContract.sol:MyContract" or artifact path relative to the project root directory
      * @param opts Common options
      * @return Address of the new implementation contract
      */
@@ -447,12 +448,8 @@ library Upgrades {
         string memory contractName,
         Options memory opts,
         bool requireReference
-    ) private pure returns (string[] memory) {
-        // TODO get defaults from foundry.toml
-        string memory outDir = opts.outDir;
-        if (bytes(outDir).length == 0) {
-            outDir = "out";
-        }
+    ) private view returns (string[] memory) {
+        string memory outDir = Utils.getOutDirWithDefaults(opts.outDir);
 
         string[] memory inputBuilder = new string[](255);
 
@@ -463,11 +460,11 @@ library Upgrades {
         inputBuilder[i++] = "validate";
         inputBuilder[i++] = string.concat(outDir, "/build-info");
         inputBuilder[i++] = "--contract";
-        inputBuilder[i++] = _toShortName(contractName);
+        inputBuilder[i++] = Utils.getFullyQualifiedName(contractName, outDir);
 
         if (bytes(opts.referenceContract).length != 0) {
             inputBuilder[i++] = "--reference";
-            inputBuilder[i++] = _toShortName(opts.referenceContract);
+            inputBuilder[i++] = Utils.getFullyQualifiedName(opts.referenceContract, outDir);
         }
 
         if (opts.unsafeSkipStorageCheck) {
@@ -492,26 +489,6 @@ library Upgrades {
         }
 
         return inputs;
-    }
-
-    function _toShortName(string memory contractName) private pure returns (string memory) {
-        strings.slice memory name = contractName.toSlice();
-        if (name.endsWith(".sol".toSlice())) {
-            return name.until(".sol".toSlice()).toString();
-        } else if (name.count(":".toSlice()) == 1) {
-            // TODO lookup artifact file and return fully qualified name to support identical contract names in different files
-            name.split(":".toSlice());
-            return name.split(":".toSlice()).toString();
-        } else {
-            // TODO support artifact file name
-            revert(
-                string.concat(
-                    "Contract name ",
-                    contractName,
-                    " must be in the format MyContract.sol:MyContract or MyContract.sol"
-                )
-            );
-        }
     }
 
     function _deploy(string memory contractName, bytes memory constructorData) private returns (address) {

--- a/src/Upgrades.sol
+++ b/src/Upgrades.sol
@@ -19,10 +19,6 @@ import {Utils} from "./internal/Utils.sol";
 
 struct Options {
     /**
-     * Foundry output directory
-     */
-    string outDir;
-    /**
      * The reference contract to use for storage layout comparisons, e.g. "ContractV1.sol" or "ContractV1.sol:ContractV1".
      * If not set, attempts to use the `@custom:oz-upgrades-from <reference>` annotation from the contract.
      */

--- a/src/internal/Utils.sol
+++ b/src/internal/Utils.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Vm} from "forge-std/Vm.sol";
+import {console} from "forge-std/console.sol";
+import {strings} from "solidity-stringutils/strings.sol";
+
+/**
+ * @dev Internal helper methods used by Upgrades and Defender libraries.
+ */
+library Utils {
+    address constant CHEATCODE_ADDRESS = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D;
+
+    /**
+     * @dev Gets the fully qualified name of a contract.
+     *
+     * @param contractName Contract name in the format "MyContract.sol" or "MyContract.sol:MyContract" or artifact path relative to the project root directory
+     * @param outDir Foundry output directory to search in if contractName is not an artifact path. Defaults to "out" if empty.
+     * @return Fully qualified name of the contract, e.g. "src/MyContract.sol:MyContract"
+     */
+    function getFullyQualifiedName(
+        string memory contractName,
+        string memory outDir
+    ) internal view returns (string memory) {
+        (string memory contractPath, string memory shortName) = getFullyQualifiedComponents(contractName, outDir);
+        return string.concat(contractPath, ":", shortName);
+    }
+
+    /**
+     * @dev Gets the short name and contract path as components of a fully qualified contract name.
+     *
+     * @param contractName Contract name in the format "MyContract.sol" or "MyContract.sol:MyContract" or artifact path relative to the project root directory
+     * @param outDir Foundry output directory to search in if contractName is not an artifact path. Defaults to "out" if empty.
+     * @return contractPath Contract path, e.g. "src/MyContract.sol"
+     * @return shortName Contract short name, e.g. "MyContract"
+     */
+    function getFullyQualifiedComponents(
+        string memory contractName,
+        string memory outDir
+    ) internal view returns (string memory contractPath, string memory shortName) {
+        Vm vm = Vm(CHEATCODE_ADDRESS);
+
+        shortName = _toShortName(contractName);
+
+        string memory fileName = _toFileName(contractName);
+
+        string memory artifactPath = string.concat(
+            vm.projectRoot(),
+            "/",
+            getOutDirWithDefaults(outDir),
+            "/",
+            fileName,
+            "/",
+            shortName,
+            ".json"
+        );
+        string memory artifactJson = vm.readFile(artifactPath);
+
+        contractPath = vm.parseJsonString(artifactJson, ".ast.absolutePath");
+    }
+
+    /**
+     * @dev Gets the output directory to search for artifacts in.
+     *
+     * @param outDir Override for the output directory. Defaults to "out" if empty.
+     */
+    function getOutDirWithDefaults(string memory outDir) internal pure returns (string memory) {
+        // TODO get defaults from foundry.toml
+        string memory result = outDir;
+        if (bytes(outDir).length == 0) {
+            result = "out";
+        }
+        return result;
+    }
+
+    using strings for *;
+
+    function _split(
+        strings.slice memory inputSlice,
+        strings.slice memory delimSlice
+    ) private pure returns (string[] memory) {
+        string[] memory parts = new string[](inputSlice.count(delimSlice) + 1);
+        for (uint i = 0; i < parts.length; i++) {
+            parts[i] = inputSlice.split(delimSlice).toString();
+        }
+        return parts;
+    }
+
+    function _toFileName(string memory contractName) private pure returns (string memory) {
+        strings.slice memory name = contractName.toSlice();
+        if (name.endsWith(".sol".toSlice())) {
+            return name.toString();
+        } else if (name.count(":".toSlice()) == 1) {
+            return name.split(":".toSlice()).toString();
+        } else {
+            if (name.endsWith(".json".toSlice())) {
+                string[] memory parts = _split(name, "/".toSlice());
+                if (parts.length > 1) {
+                    return parts[parts.length - 2];
+                }
+            }
+
+            revert(
+                string.concat(
+                    "Contract name ",
+                    contractName,
+                    " must be in the format MyContract.sol:MyContract or MyContract.sol or out/MyContract.sol/MyContract.json"
+                )
+            );
+        }
+    }
+
+    function _toShortName(string memory contractName) private pure returns (string memory) {
+        strings.slice memory name = contractName.toSlice();
+        if (name.endsWith(".sol".toSlice())) {
+            return name.until(".sol".toSlice()).toString();
+        } else if (name.count(":".toSlice()) == 1) {
+            name.split(":".toSlice());
+            return name.split(":".toSlice()).toString();
+        } else if (name.endsWith(".json".toSlice())) {
+            string[] memory parts = _split(name, "/".toSlice());
+            string memory jsonName = parts[parts.length - 1];
+            return jsonName.toSlice().until(".json".toSlice()).toString();
+        } else {
+            revert(
+                string.concat(
+                    "Contract name ",
+                    contractName,
+                    " must be in the format MyContract.sol:MyContract or MyContract.sol or out/MyContract.sol/MyContract.json"
+                )
+            );
+        }
+    }
+}

--- a/src/internal/Utils.sol
+++ b/src/internal/Utils.sol
@@ -15,7 +15,7 @@ library Utils {
      * @dev Gets the fully qualified name of a contract.
      *
      * @param contractName Contract name in the format "MyContract.sol" or "MyContract.sol:MyContract" or artifact path relative to the project root directory
-     * @param outDir Foundry output directory to search in if contractName is not an artifact path. Defaults to "out" if empty.
+     * @param outDir Foundry output directory to search in if contractName is not an artifact path
      * @return Fully qualified name of the contract, e.g. "src/MyContract.sol:MyContract"
      */
     function getFullyQualifiedName(
@@ -30,7 +30,7 @@ library Utils {
      * @dev Gets the short name and contract path as components of a fully qualified contract name.
      *
      * @param contractName Contract name in the format "MyContract.sol" or "MyContract.sol:MyContract" or artifact path relative to the project root directory
-     * @param outDir Foundry output directory to search in if contractName is not an artifact path. Defaults to "out" if empty.
+     * @param outDir Foundry output directory to search in if contractName is not an artifact path
      * @return contractPath Contract path, e.g. "src/MyContract.sol"
      * @return shortName Contract short name, e.g. "MyContract"
      */
@@ -47,7 +47,7 @@ library Utils {
         string memory artifactPath = string.concat(
             vm.projectRoot(),
             "/",
-            getOutDirWithDefaults(outDir),
+            outDir,
             "/",
             fileName,
             "/",
@@ -60,15 +60,15 @@ library Utils {
     }
 
     /**
-     * @dev Gets the output directory to search for artifacts in.
-     *
-     * @param outDir Override for the output directory. Defaults to "out" if empty.
+     * @dev Gets the output directory from the FOUNDRY_OUT environment variable, or defaults to "out" if not set or is empty.
      */
-    function getOutDirWithDefaults(string memory outDir) internal pure returns (string memory) {
-        // TODO get defaults from foundry.toml
-        string memory result = outDir;
-        if (bytes(outDir).length == 0) {
-            result = "out";
+    function getOutDir() internal returns (string memory) {
+        Vm vm = Vm(CHEATCODE_ADDRESS);
+
+        string memory defaultOutDir = "out";
+        string memory result = vm.envOr("FOUNDRY_OUT", defaultOutDir);
+        if (bytes(result).length == 0) {
+            result = defaultOutDir;
         }
         return result;
     }

--- a/src/internal/Utils.sol
+++ b/src/internal/Utils.sol
@@ -60,17 +60,13 @@ library Utils {
     }
 
     /**
-     * @dev Gets the output directory from the FOUNDRY_OUT environment variable, or defaults to "out" if not set or is empty.
+     * @dev Gets the output directory from the FOUNDRY_OUT environment variable, or defaults to "out" if not set.
      */
     function getOutDir() internal returns (string memory) {
         Vm vm = Vm(CHEATCODE_ADDRESS);
 
         string memory defaultOutDir = "out";
-        string memory result = vm.envOr("FOUNDRY_OUT", defaultOutDir);
-        if (bytes(result).length == 0) {
-            result = defaultOutDir;
-        }
-        return result;
+        return vm.envOr("FOUNDRY_OUT", defaultOutDir);
     }
 
     using strings for *;

--- a/src/internal/Versions.sol
+++ b/src/internal/Versions.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
 library Versions {

--- a/test/Utils.t.sol
+++ b/test/Utils.t.sol
@@ -45,6 +45,16 @@ contract UpgradesTest is Test {
         }
     }
 
+    function testGetFullyQualifiedComponents_outDirTrailingSlash() public {
+        (string memory contractPath, string memory shortName) = Utils.getFullyQualifiedComponents(
+            "Greeter.sol",
+            "out/"
+        );
+
+        assertEq(shortName, "Greeter");
+        assertEq(contractPath, "test/contracts/Greeter.sol");
+    }
+
     function testGetFullyQualifiedComponents_invalidOutDir() public {
         Invoker c = new Invoker();
         try c.getFullyQualifiedComponents("Greeter.sol", "invalidoutdir") {

--- a/test/Utils.t.sol
+++ b/test/Utils.t.sol
@@ -7,7 +7,7 @@ import {Utils} from "openzeppelin-foundry-upgrades/internal/Utils.sol";
 
 contract UpgradesTest is Test {
     function testGetFullyQualifiedComponents_from_file() public {
-        (string memory contractPath, string memory shortName) = Utils.getFullyQualifiedComponents("Greeter.sol", "");
+        (string memory contractPath, string memory shortName) = Utils.getFullyQualifiedComponents("Greeter.sol", "out");
 
         assertEq(shortName, "Greeter");
         assertEq(contractPath, "test/contracts/Greeter.sol");
@@ -16,7 +16,7 @@ contract UpgradesTest is Test {
     function testGetFullyQualifiedComponents_from_fileAndName() public {
         (string memory contractPath, string memory shortName) = Utils.getFullyQualifiedComponents(
             "MyContractFile.sol:MyContractName",
-            ""
+            "out"
         );
 
         assertEq(shortName, "MyContractName");
@@ -26,7 +26,7 @@ contract UpgradesTest is Test {
     function testGetFullyQualifiedComponents_from_artifact() public {
         (string memory contractPath, string memory shortName) = Utils.getFullyQualifiedComponents(
             "out/MyContractFile.sol/MyContractName.json",
-            ""
+            "out"
         );
 
         assertEq(shortName, "MyContractName");
@@ -35,7 +35,7 @@ contract UpgradesTest is Test {
 
     function testGetFullyQualifiedComponents_wrongNameFormat() public {
         Invoker c = new Invoker();
-        try c.getFullyQualifiedComponents("Foo", "") {
+        try c.getFullyQualifiedComponents("Foo", "out") {
             fail();
         } catch Error(string memory reason) {
             assertEq(
@@ -53,26 +53,26 @@ contract UpgradesTest is Test {
     }
 
     function testGetFullyQualifiedName_from_file() public {
-        string memory fqName = Utils.getFullyQualifiedName("Greeter.sol", "");
+        string memory fqName = Utils.getFullyQualifiedName("Greeter.sol", "out");
 
         assertEq(fqName, "test/contracts/Greeter.sol:Greeter");
     }
 
     function testGetFullyQualifiedName_from_fileAndName() public {
-        string memory fqName = Utils.getFullyQualifiedName("MyContractFile.sol:MyContractName", "");
+        string memory fqName = Utils.getFullyQualifiedName("MyContractFile.sol:MyContractName", "out");
 
         assertEq(fqName, "test/contracts/MyContractFile.sol:MyContractName");
     }
 
     function testGetFullyQualifiedName_from_artifact() public {
-        string memory fqName = Utils.getFullyQualifiedName("out/MyContractFile.sol/MyContractName.json", "");
+        string memory fqName = Utils.getFullyQualifiedName("out/MyContractFile.sol/MyContractName.json", "out");
 
         assertEq(fqName, "test/contracts/MyContractFile.sol:MyContractName");
     }
 
     function testGetFullyQualifiedName_wrongNameFormat() public {
         Invoker i = new Invoker();
-        try i.getFullyQualifiedName("Foo", "") {
+        try i.getFullyQualifiedName("Foo", "out") {
             fail();
         } catch Error(string memory reason) {
             assertEq(
@@ -89,10 +89,8 @@ contract UpgradesTest is Test {
         } catch {}
     }
 
-    function testGetOutDirWithDefaults() public {
-        assertEq(Utils.getOutDirWithDefaults(""), "out");
-        assertEq(Utils.getOutDirWithDefaults("out"), "out");
-        assertEq(Utils.getOutDirWithDefaults("foo"), "foo");
+    function testGetOutDir() public {
+        assertEq(Utils.getOutDir(), "out");
     }
 }
 

--- a/test/Utils.t.sol
+++ b/test/Utils.t.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {Utils} from "openzeppelin-foundry-upgrades/internal/Utils.sol";
+
+contract UpgradesTest is Test {
+    function testGetFullyQualifiedComponents_from_file() public {
+        (string memory contractPath, string memory shortName) = Utils.getFullyQualifiedComponents("Greeter.sol", "");
+
+        assertEq(shortName, "Greeter");
+        assertEq(contractPath, "test/contracts/Greeter.sol");
+    }
+
+    function testGetFullyQualifiedComponents_from_fileAndName() public {
+        (string memory contractPath, string memory shortName) = Utils.getFullyQualifiedComponents(
+            "MyContractFile.sol:MyContractName",
+            ""
+        );
+
+        assertEq(shortName, "MyContractName");
+        assertEq(contractPath, "test/contracts/MyContractFile.sol");
+    }
+
+    function testGetFullyQualifiedComponents_from_artifact() public {
+        (string memory contractPath, string memory shortName) = Utils.getFullyQualifiedComponents(
+            "out/MyContractFile.sol/MyContractName.json",
+            ""
+        );
+
+        assertEq(shortName, "MyContractName");
+        assertEq(contractPath, "test/contracts/MyContractFile.sol");
+    }
+
+    function testGetFullyQualifiedComponents_wrongNameFormat() public {
+        Invoker c = new Invoker();
+        try c.getFullyQualifiedComponents("Foo", "") {
+            fail();
+        } catch Error(string memory reason) {
+            assertEq(
+                reason,
+                "Contract name Foo must be in the format MyContract.sol:MyContract or MyContract.sol or out/MyContract.sol/MyContract.json"
+            );
+        }
+    }
+
+    function testGetFullyQualifiedComponents_invalidOutDir() public {
+        Invoker c = new Invoker();
+        try c.getFullyQualifiedComponents("Greeter.sol", "invalidoutdir") {
+            fail();
+        } catch {}
+    }
+
+    function testGetFullyQualifiedName_from_file() public {
+        string memory fqName = Utils.getFullyQualifiedName("Greeter.sol", "");
+
+        assertEq(fqName, "test/contracts/Greeter.sol:Greeter");
+    }
+
+    function testGetFullyQualifiedName_from_fileAndName() public {
+        string memory fqName = Utils.getFullyQualifiedName("MyContractFile.sol:MyContractName", "");
+
+        assertEq(fqName, "test/contracts/MyContractFile.sol:MyContractName");
+    }
+
+    function testGetFullyQualifiedName_from_artifact() public {
+        string memory fqName = Utils.getFullyQualifiedName("out/MyContractFile.sol/MyContractName.json", "");
+
+        assertEq(fqName, "test/contracts/MyContractFile.sol:MyContractName");
+    }
+
+    function testGetFullyQualifiedName_wrongNameFormat() public {
+        Invoker i = new Invoker();
+        try i.getFullyQualifiedName("Foo", "") {
+            fail();
+        } catch Error(string memory reason) {
+            assertEq(
+                reason,
+                "Contract name Foo must be in the format MyContract.sol:MyContract or MyContract.sol or out/MyContract.sol/MyContract.json"
+            );
+        }
+    }
+
+    function testGetFullyQualifiedName_invalidOutDir() public {
+        Invoker i = new Invoker();
+        try i.getFullyQualifiedName("Greeter.sol", "invalidoutdir") {
+            fail();
+        } catch {}
+    }
+
+    function testGetOutDirWithDefaults() public {
+        assertEq(Utils.getOutDirWithDefaults(""), "out");
+        assertEq(Utils.getOutDirWithDefaults("out"), "out");
+        assertEq(Utils.getOutDirWithDefaults("foo"), "foo");
+    }
+}
+
+contract Invoker {
+    function getFullyQualifiedComponents(string memory contractName, string memory outDir) public view {
+        Utils.getFullyQualifiedComponents(contractName, outDir);
+    }
+
+    function getFullyQualifiedName(string memory contractName, string memory outDir) public view {
+        Utils.getFullyQualifiedName(contractName, outDir);
+    }
+}

--- a/test/contracts/MyContractFile.sol
+++ b/test/contracts/MyContractFile.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+// This contract is for testing only.
+
+contract MyContractName {
+
+}


### PR DESCRIPTION
Abstract:

- Add helper functions in `Utils.sol` to get a fully qualified contract name or its components.
- Support passing in artifact file paths to `Upgrades.sol` functions.

User-facing changes:

We previously supported passing in contract names in the format "MyContract.sol" or "MyContract.sol:MyContract".  With the additional changes, we can now also support passing in an artifact file path, so that we are compatible with all formats accepted by Foundry's [vm.getCode](https://book.getfoundry.sh/cheatcodes/get-code?highlight=getcode#getcode) cheatcode.

Motivation:

- `upgrades-core` CLI accepts fully qualified contract names in its `--contract` or `--reference` parameters, which avoids ambiguity if there are multiple contracts with the same name in different files.  We want to find the fully qualified names and pass these to the CLI.

- Defender SDK requires fully qualified components (name and contract path) for deployments, which we intend to eventually use.

How:

- Infer the file name and contract name from the given input, look up the artifact file using these, and read the artifact file's JSON to get the absolute path of the source file.  This gives us the contract path component of the fully qualified name.

---

## Breaking changes
- The `outDir` option is no longer available.  If you have a custom `out` directory in foundry.toml, set the `FOUNDRY_OUT` environment variable to that directory.  You can set this environment variable using a `.env` file in your project.