### PR TITLE
Update forge-std, fix compiler warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.2.0 (2024-03-20)
 
 - Update forge-std to v1.8.0, restrict state mutability of some functions. ([#30](https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/pull/30))
 
@@ -9,7 +9,7 @@
 
 ## 0.1.0 (2024-03-11)
 
-- Support private networks and forked networks with Defender.
+- Support private networks and forked networks with Defender. ([#25](https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/pull/25))
 
 ## 0.0.2 (2024-02-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-- Update forge-std to v1.8.0, fix compiler warnings. ([#30](https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/pull/30))
+- Update forge-std to v1.8.0, restrict state mutabilitiy of some functions. ([#30](https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/pull/30))
+
+### Breaking changes
+- Requires forge-std version v1.8.0 or later.
 
 ## 0.1.0 (2024-03-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Update forge-std to v1.8.0, restrict state mutabilitiy of some functions. ([#30](https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/pull/30))
+- Update forge-std to v1.8.0, restrict state mutability of some functions. ([#30](https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/pull/30))
 
 ### Breaking changes
 - Requires forge-std version v1.8.0 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Update forge-std to v1.8.0, fix compiler warnings. ([#30](https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/pull/30))
+
 ## 0.1.0 (2024-03-11)
 
 - Support private networks and forked networks with Defender.

--- a/src/Upgrades.sol
+++ b/src/Upgrades.sol
@@ -441,7 +441,7 @@ library Upgrades {
         string memory contractName,
         Options memory opts,
         bool requireReference
-    ) private returns (string[] memory) {
+    ) private view returns (string[] memory) {
         string memory outDir = Utils.getOutDir();
 
         string[] memory inputBuilder = new string[](255);

--- a/src/internal/Utils.sol
+++ b/src/internal/Utils.sol
@@ -130,7 +130,7 @@ library Utils {
     /**
      * @dev Gets the output directory from the FOUNDRY_OUT environment variable, or defaults to "out" if not set.
      */
-    function getOutDir() internal returns (string memory) {
+    function getOutDir() internal view returns (string memory) {
         Vm vm = Vm(CHEATCODE_ADDRESS);
 
         string memory defaultOutDir = "out";

--- a/test/UpgradesUseDefenderDeploy.t.sol
+++ b/test/UpgradesUseDefenderDeploy.t.sol
@@ -28,7 +28,7 @@ contract UpgradesUseDefenderDeployTest is Test {
         d = new Deployer();
     }
 
-    function _assertDefenderNotAvailable(strings.slice memory slice) private {
+    function _assertDefenderNotAvailable(strings.slice memory slice) private pure {
         assertTrue(
             slice.contains(
                 "The current network with chainId 31337 is not supported by OpenZeppelin Defender".toSlice()

--- a/test/contracts/Validations.sol
+++ b/test/contracts/Validations.sol
@@ -5,7 +5,8 @@ pragma solidity ^0.8.20;
 
 contract Unsafe {
     function unsafe() public {
-        selfdestruct(payable(msg.sender));
+        (bool s, ) = msg.sender.delegatecall("");
+        s;
     }
 }
 

--- a/test/internal/DefenderDeploy.t.sol
+++ b/test/internal/DefenderDeploy.t.sol
@@ -178,7 +178,7 @@ contract DefenderDeployTest is Test {
         assertEq(response.viaType, "Relayer");
     }
 
-    function testParseApprovalProcessResponseIdOnly() public pure{
+    function testParseApprovalProcessResponseIdOnly() public pure {
         string memory output = "Approval process ID: abc";
 
         ApprovalProcessResponse memory response = DefenderDeploy.parseApprovalProcessResponse(output);

--- a/test/internal/DefenderDeploy.t.sol
+++ b/test/internal/DefenderDeploy.t.sol
@@ -109,7 +109,7 @@ contract DefenderDeployTest is Test {
         );
     }
 
-    function testBuildProposeUpgradeCommand() public {
+    function testBuildProposeUpgradeCommand() public view {
         ContractInfo memory contractInfo = Utils.getContractInfo("MyContractFile.sol:MyContractName", "out");
 
         Options memory opts;
@@ -134,7 +134,7 @@ contract DefenderDeployTest is Test {
         );
     }
 
-    function testParseProposeUpgradeResponse() public {
+    function testParseProposeUpgradeResponse() public pure {
         string memory output = "Upgrade proposal created.\nProposal ID: 123\nProposal URL: https://my.url/my-tx";
 
         ProposeUpgradeResponse memory response = DefenderDeploy.parseProposeUpgradeResponse(output);
@@ -143,7 +143,7 @@ contract DefenderDeployTest is Test {
         assertEq(response.url, "https://my.url/my-tx");
     }
 
-    function testParseProposeUpgradeResponseNoUrl() public {
+    function testParseProposeUpgradeResponseNoUrl() public pure {
         string memory output = "Upgrade proposal created.\nProposal ID: 123";
 
         ProposeUpgradeResponse memory response = DefenderDeploy.parseProposeUpgradeResponse(output);
@@ -152,7 +152,7 @@ contract DefenderDeployTest is Test {
         assertEq(response.url, "");
     }
 
-    function testBuildGetApprovalProcessCommand() public {
+    function testBuildGetApprovalProcessCommand() public view {
         string memory commandString = _toString(
             DefenderDeploy.buildGetApprovalProcessCommand("getDeployApprovalProcess")
         );
@@ -167,7 +167,7 @@ contract DefenderDeployTest is Test {
         );
     }
 
-    function testParseApprovalProcessResponse() public {
+    function testParseApprovalProcessResponse() public pure {
         string
             memory output = "Approval process ID: abc\nVia: 0x1230000000000000000000000000000000000456\nVia type: Relayer";
 
@@ -178,7 +178,7 @@ contract DefenderDeployTest is Test {
         assertEq(response.viaType, "Relayer");
     }
 
-    function testParseApprovalProcessResponseIdOnly() public {
+    function testParseApprovalProcessResponseIdOnly() public pure{
         string memory output = "Approval process ID: abc";
 
         ApprovalProcessResponse memory response = DefenderDeploy.parseApprovalProcessResponse(output);

--- a/test/internal/Utils.t.sol
+++ b/test/internal/Utils.t.sol
@@ -10,7 +10,7 @@ import {Utils, ContractInfo} from "openzeppelin-foundry-upgrades/internal/Utils.
  * @dev Tests the Utils internal library.
  */
 contract UtilsTest is Test {
-    function testGetContractInfo_from_file() public {
+    function testGetContractInfo_from_file() public view {
         ContractInfo memory info = Utils.getContractInfo("Greeter.sol", "out");
 
         assertEq(info.shortName, "Greeter");
@@ -20,14 +20,14 @@ contract UtilsTest is Test {
         assertEq(info.sourceCodeHash, "0xf9875b1fd90da13f5f990d5ba7e66481f4b7e13e4a8f57fa9145fe90a1cb9324"); // source code hash of Greeter.sol
     }
 
-    function testGetContractInfo_from_fileAndName() public {
+    function testGetContractInfo_from_fileAndName() public view {
         ContractInfo memory info = Utils.getContractInfo("MyContractFile.sol:MyContractName", "out");
 
         assertEq(info.shortName, "MyContractName");
         assertEq(info.contractPath, "test/contracts/MyContractFile.sol");
     }
 
-    function testGetContractInfo_from_artifact() public {
+    function testGetContractInfo_from_artifact() public view {
         ContractInfo memory info = Utils.getContractInfo("out/MyContractFile.sol/MyContractName.json", "out");
 
         assertEq(info.shortName, "MyContractName");
@@ -46,7 +46,7 @@ contract UtilsTest is Test {
         }
     }
 
-    function testGetContractInfo_outDirTrailingSlash() public {
+    function testGetContractInfo_outDirTrailingSlash() public view {
         ContractInfo memory info = Utils.getContractInfo("Greeter.sol", "out/");
 
         assertEq(info.shortName, "Greeter");
@@ -60,19 +60,19 @@ contract UtilsTest is Test {
         } catch {}
     }
 
-    function testGetFullyQualifiedName_from_file() public {
+    function testGetFullyQualifiedName_from_file() public view {
         string memory fqName = Utils.getFullyQualifiedName("Greeter.sol", "out");
 
         assertEq(fqName, "test/contracts/Greeter.sol:Greeter");
     }
 
-    function testGetFullyQualifiedName_from_fileAndName() public {
+    function testGetFullyQualifiedName_from_fileAndName() public view {
         string memory fqName = Utils.getFullyQualifiedName("MyContractFile.sol:MyContractName", "out");
 
         assertEq(fqName, "test/contracts/MyContractFile.sol:MyContractName");
     }
 
-    function testGetFullyQualifiedName_from_artifact() public {
+    function testGetFullyQualifiedName_from_artifact() public view {
         string memory fqName = Utils.getFullyQualifiedName("out/MyContractFile.sol/MyContractName.json", "out");
 
         assertEq(fqName, "test/contracts/MyContractFile.sol:MyContractName");
@@ -97,7 +97,7 @@ contract UtilsTest is Test {
         } catch {}
     }
 
-    function testGetOutDir() public {
+    function testGetOutDir() public view {
         assertEq(Utils.getOutDir(), "out");
     }
 
@@ -115,7 +115,7 @@ contract UtilsTest is Test {
         assertTrue(buildInfoFile.toSlice().endsWith(".json".toSlice()));
     }
 
-    function testToBashCommand() public {
+    function testToBashCommand() public pure {
         string[] memory inputs = new string[](3);
         inputs[0] = "foo";
         inputs[1] = "param";


### PR DESCRIPTION
- Updates forge-std to v1.8.0, restrict state mutability of some functions to avoid compiler warnings.
   - **Note**: This is a breaking change, requiring the user's project to use forge-std v1.8.0 or later.
- One of the test contracts in this project has a selfdestruct, which we use as part of the upgrade safety validation tests.  However, this gives a compiler warning since selfdestruct is deprecated.  This PR changes this tescase to use a delegatecall instead.
