### PR TITLE
Add `UnsafeUpgrades` library for use with `forge coverage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Add `UnsafeUpgrades.sol` for use with code coverage testing.
+- Add `UnsafeUpgrades` library for use with `forge coverage`. ([#45](https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/pull/45))
 
 ## 0.2.2 (2024-04-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add `UnsafeUpgrades.sol` for use with code coverage testing.
+
 ## 0.2.2 (2024-04-17)
 
 - Defender: Fix handling of license types for block explorer verification, support `licenseType` and `skipLicenseType` options. ([#43](https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/pull/43))

--- a/README.md
+++ b/README.md
@@ -177,4 +177,4 @@ address proxy = Upgrades.deployUUPSProxy(
 ```
 
 > **Warning**
-[UnsafeUpgrades.sol](src/UnsafeUpgrades.sol) does not validate whether your contracts are upgrade safe or whether new implementations are compatible with previous ones. Ensure you run validations before any actual deployments or upgrades, such as by using [Upgrades.sol](src/Upgrades.sol) in scripts.
+[UnsafeUpgrades.sol](src/UnsafeUpgrades.sol) is not recommended for use in Forge scripts. It does not validate whether your contracts are upgrade safe or whether new implementations are compatible with previous ones. Ensure you run validations before any actual deployments or upgrades, such as by using [Upgrades.sol](src/Upgrades.sol) in scripts.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ extra_output = ["storageLayout"]
 3. If you are upgrading your contract from a previous version, add the `@custom:oz-upgrades-from <reference>` annotation to the new version of your contract according to [Define Reference Contracts](https://docs.openzeppelin.com/upgrades-plugins/1.x/api-core#define-reference-contracts) or specify the `referenceContract` option when calling the library's functions.
 4. Run `forge clean` before running your Foundry script or tests, or include the `--force` option when running `forge script` or `forge test`.
 
-If you do not want to run upgrade safety checks, you can skip the above steps and use the `unsafeSkipAllChecks` option when calling the library's functions. Note that this is a dangerous option meant to be used as a last resort.
+If you do not want to run upgrade safety checks, you can skip the above steps and use the [`unsafeSkipAllChecks` option](src/Options.sol) when calling `Upgrades` library's functions, or use [UnsafeUpgrades.sol](src/UnsafeUpgrades.sol) instead. Note that these are dangerous options meant to be used as a last resort.
 
 ### Output directory configuration
 

--- a/README.md
+++ b/README.md
@@ -164,3 +164,17 @@ Run your script with `forge script` to broadcast and deploy. See Foundry's [Soli
 
 > **Note**
 > Include the `--verify` flag for the `forge script` command if you want to verify source code such as on Etherscan. This will verify your implementation contracts along with any proxy contracts as part of the deployment.
+
+### Coverage Testing
+
+To enable code coverage reports with `forge coverage`, use the following deployment pattern in your tests: instantiate your implementation contracts directly and use [UnsafeUpgrades.sol](src/UnsafeUpgrades.sol). For example:
+```solidity
+address implementation = address(new MyContract());
+address proxy = Upgrades.deployUUPSProxy(
+    implementation,
+    abi.encodeCall(MyContract.initialize, ("arguments for the initialize function"))
+);
+```
+
+> **Warning**
+[UnsafeUpgrades.sol](src/UnsafeUpgrades.sol) does not validate whether your contracts are upgrade safe or whether new implementations are compatible with previous ones. Ensure you run validations before any actual deployments or upgrades, such as by using [Upgrades.sol](src/Upgrades.sol) in scripts.

--- a/docs/modules/api/pages/api-foundry-upgrades.adoc
+++ b/docs/modules/api/pages/api-foundry-upgrades.adoc
@@ -23,6 +23,7 @@
 :xref-Upgrades-getImplementationAddress-address-: xref:#Upgrades-getImplementationAddress-address-
 :xref-Upgrades-getBeaconAddress-address-: xref:#Upgrades-getBeaconAddress-address-
 :xref-Upgrades-tryPrank-address-: xref:#Upgrades-tryPrank-address-
+:xref-Upgrades-CHEATCODE_ADDRESS-address: xref:#Upgrades-CHEATCODE_ADDRESS-address
 :xref-UnsafeUpgrades-deployUUPSProxy-address-bytes-: xref:#UnsafeUpgrades-deployUUPSProxy-address-bytes-
 :xref-UnsafeUpgrades-deployTransparentProxy-address-address-bytes-: xref:#UnsafeUpgrades-deployTransparentProxy-address-address-bytes-
 :xref-UnsafeUpgrades-upgradeProxy-address-address-bytes-: xref:#UnsafeUpgrades-upgradeProxy-address-address-bytes-
@@ -111,6 +112,7 @@ struct DefenderOptions {
 :getImplementationAddress: pass:normal[xref:#Upgrades-getImplementationAddress-address-[`++getImplementationAddress++`]]
 :getBeaconAddress: pass:normal[xref:#Upgrades-getBeaconAddress-address-[`++getBeaconAddress++`]]
 :tryPrank: pass:normal[xref:#Upgrades-tryPrank-address-[`++tryPrank++`]]
+:CHEATCODE_ADDRESS: pass:normal[xref:#Upgrades-CHEATCODE_ADDRESS-address[`++CHEATCODE_ADDRESS++`]]
 
 [.contract]
 [[Upgrades]]
@@ -156,6 +158,13 @@ Library for deploying and managing upgradeable contracts from Forge scripts or t
 .Modifiers
 --
 * {xref-Upgrades-tryPrank-address-}[`++tryPrank(deployer)++`]
+--
+
+[.contract-index]
+.Internal Variables
+--
+* {xref-Upgrades-CHEATCODE_ADDRESS-address}[`++address constant CHEATCODE_ADDRESS++`]
+
 --
 
 [.contract-item]
@@ -527,6 +536,10 @@ Gets the beacon address of a beacon proxy from its ERC1967 beacon storage slot.
 
 Runs a function as a prank, or just runs the function normally if the prank could not be started.
 
+[.contract-item]
+[[Upgrades-CHEATCODE_ADDRESS-address]]
+==== `address [.contract-item-name]#++CHEATCODE_ADDRESS++#` [.item-kind]#internal constant#
+
 :deployUUPSProxy: pass:normal[xref:#UnsafeUpgrades-deployUUPSProxy-address-bytes-[`++deployUUPSProxy++`]]
 :deployTransparentProxy: pass:normal[xref:#UnsafeUpgrades-deployTransparentProxy-address-address-bytes-[`++deployTransparentProxy++`]]
 :upgradeProxy: pass:normal[xref:#UnsafeUpgrades-upgradeProxy-address-address-bytes-[`++upgradeProxy++`]]
@@ -550,6 +563,7 @@ Library for deploying and managing upgradeable contracts from Forge tests, witho
 
 Requires implementation contracts to be instantiated first. Can be used with `forge coverage`.
 Does not require `--ffi` and does not require a clean compilation before each run.
+Not supported for OpenZeppelin Defender deployments.
 
 WARNING: Not recommended for use in Forge scripts.
 UnsafeUpgrades.sol does not validate whether your contracts are upgrade safe or whether new implementations are compatible with previous ones.

--- a/docs/modules/api/pages/api-foundry-upgrades.adoc
+++ b/docs/modules/api/pages/api-foundry-upgrades.adoc
@@ -23,7 +23,15 @@
 :xref-Upgrades-getImplementationAddress-address-: xref:#Upgrades-getImplementationAddress-address-
 :xref-Upgrades-getBeaconAddress-address-: xref:#Upgrades-getBeaconAddress-address-
 :xref-Upgrades-tryPrank-address-: xref:#Upgrades-tryPrank-address-
-:xref-Upgrades-CHEATCODE_ADDRESS-address: xref:#Upgrades-CHEATCODE_ADDRESS-address
+:xref-UnsafeUpgrades-deployUUPSProxy-address-bytes-: xref:#UnsafeUpgrades-deployUUPSProxy-address-bytes-
+:xref-UnsafeUpgrades-deployTransparentProxy-address-address-bytes-: xref:#UnsafeUpgrades-deployTransparentProxy-address-address-bytes-
+:xref-UnsafeUpgrades-upgradeProxy-address-address-bytes-: xref:#UnsafeUpgrades-upgradeProxy-address-address-bytes-
+:xref-UnsafeUpgrades-upgradeProxy-address-address-bytes-address-: xref:#UnsafeUpgrades-upgradeProxy-address-address-bytes-address-
+:xref-UnsafeUpgrades-deployBeacon-address-address-: xref:#UnsafeUpgrades-deployBeacon-address-address-
+:xref-UnsafeUpgrades-upgradeBeacon-address-address-: xref:#UnsafeUpgrades-upgradeBeacon-address-address-
+:xref-UnsafeUpgrades-upgradeBeacon-address-address-address-: xref:#UnsafeUpgrades-upgradeBeacon-address-address-address-
+:xref-UnsafeUpgrades-deployBeaconProxy-address-bytes-: xref:#UnsafeUpgrades-deployBeaconProxy-address-bytes-
+:xref-UnsafeUpgrades-tryPrank-address-: xref:#UnsafeUpgrades-tryPrank-address-
 :xref-Defender-deployContract-string-: xref:#Defender-deployContract-string-
 :xref-Defender-deployContract-string-struct-DefenderOptions-: xref:#Defender-deployContract-string-struct-DefenderOptions-
 :xref-Defender-deployContract-string-bytes-: xref:#Defender-deployContract-string-bytes-
@@ -103,7 +111,6 @@ struct DefenderOptions {
 :getImplementationAddress: pass:normal[xref:#Upgrades-getImplementationAddress-address-[`++getImplementationAddress++`]]
 :getBeaconAddress: pass:normal[xref:#Upgrades-getBeaconAddress-address-[`++getBeaconAddress++`]]
 :tryPrank: pass:normal[xref:#Upgrades-tryPrank-address-[`++tryPrank++`]]
-:CHEATCODE_ADDRESS: pass:normal[xref:#Upgrades-CHEATCODE_ADDRESS-address[`++CHEATCODE_ADDRESS++`]]
 
 [.contract]
 [[Upgrades]]
@@ -114,7 +121,7 @@ struct DefenderOptions {
 import { Upgrades } from "openzeppelin-foundry-upgrades/Upgrades.sol";
 ```
 
-Library for deploying and managing upgradeable contracts from Forge scripts or tests.
+Library for deploying and managing upgradeable contracts from Forge scripts or tests, with validations that run before each deployment.
 
 [.contract-index]
 .Functions
@@ -149,13 +156,6 @@ Library for deploying and managing upgradeable contracts from Forge scripts or t
 .Modifiers
 --
 * {xref-Upgrades-tryPrank-address-}[`++tryPrank(deployer)++`]
---
-
-[.contract-index]
-.Internal Variables
---
-* {xref-Upgrades-CHEATCODE_ADDRESS-address}[`++address constant CHEATCODE_ADDRESS++`]
-
 --
 
 [.contract-item]
@@ -527,11 +527,179 @@ Gets the beacon address of a beacon proxy from its ERC1967 beacon storage slot.
 
 Runs a function as a prank, or just runs the function normally if the prank could not be started.
 
-[.contract-item]
-[[Upgrades-CHEATCODE_ADDRESS-address]]
-==== `address [.contract-item-name]#++CHEATCODE_ADDRESS++#` [.item-kind]#internal constant#
+:deployUUPSProxy: pass:normal[xref:#UnsafeUpgrades-deployUUPSProxy-address-bytes-[`++deployUUPSProxy++`]]
+:deployTransparentProxy: pass:normal[xref:#UnsafeUpgrades-deployTransparentProxy-address-address-bytes-[`++deployTransparentProxy++`]]
+:upgradeProxy: pass:normal[xref:#UnsafeUpgrades-upgradeProxy-address-address-bytes-[`++upgradeProxy++`]]
+:upgradeProxy: pass:normal[xref:#UnsafeUpgrades-upgradeProxy-address-address-bytes-address-[`++upgradeProxy++`]]
+:deployBeacon: pass:normal[xref:#UnsafeUpgrades-deployBeacon-address-address-[`++deployBeacon++`]]
+:upgradeBeacon: pass:normal[xref:#UnsafeUpgrades-upgradeBeacon-address-address-[`++upgradeBeacon++`]]
+:upgradeBeacon: pass:normal[xref:#UnsafeUpgrades-upgradeBeacon-address-address-address-[`++upgradeBeacon++`]]
+:deployBeaconProxy: pass:normal[xref:#UnsafeUpgrades-deployBeaconProxy-address-bytes-[`++deployBeaconProxy++`]]
+:tryPrank: pass:normal[xref:#UnsafeUpgrades-tryPrank-address-[`++tryPrank++`]]
 
-== Foundry Defender
+[.contract]
+[[UnsafeUpgrades]]
+=== `++UnsafeUpgrades++` link:https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/blob/main/src/UnsafeUpgrades.sol[{github-icon},role=heading-link]
+
+[.hljs-theme-light.nopadding]
+```solidity
+import { UnsafeUpgrades } from "openzeppelin-foundry-upgrades/UnsafeUpgrades.sol";
+```
+
+Library for deploying and managing upgradeable contracts from Forge scripts or tests, without validations.
+
+Requires implementation contracts to be deployed first.
+
+Works with `forge coverage`.
+Does not require `--ffi` and does not require a clean compilation before each run.
+
+WARNING: UnsafeUpgrades.sol does not validate whether your contracts are upgrade safe or whether new implementations are compatible with previous ones.
+Use Upgrades.sol if you want validations to be run.
+
+[.contract-index]
+.Functions
+--
+* {xref-UnsafeUpgrades-deployUUPSProxy-address-bytes-}[`++deployUUPSProxy(impl, initializerData)++`]
+* {xref-UnsafeUpgrades-deployTransparentProxy-address-address-bytes-}[`++deployTransparentProxy(impl, initialOwner, initializerData)++`]
+* {xref-UnsafeUpgrades-upgradeProxy-address-address-bytes-}[`++upgradeProxy(proxy, newImpl, data)++`]
+* {xref-UnsafeUpgrades-upgradeProxy-address-address-bytes-address-}[`++upgradeProxy(proxy, newImpl, data, tryCaller)++`]
+* {xref-UnsafeUpgrades-deployBeacon-address-address-}[`++deployBeacon(impl, initialOwner)++`]
+* {xref-UnsafeUpgrades-upgradeBeacon-address-address-}[`++upgradeBeacon(beacon, newImpl)++`]
+* {xref-UnsafeUpgrades-upgradeBeacon-address-address-address-}[`++upgradeBeacon(beacon, newImpl, tryCaller)++`]
+* {xref-UnsafeUpgrades-deployBeaconProxy-address-bytes-}[`++deployBeaconProxy(beacon, data)++`]
+
+--
+
+[.contract-index]
+.Modifiers
+--
+* {xref-UnsafeUpgrades-tryPrank-address-}[`++tryPrank(deployer)++`]
+--
+
+[.contract-item]
+[[UnsafeUpgrades-deployUUPSProxy-address-bytes-]]
+==== `[.contract-item-name]#++deployUUPSProxy++#++(address impl, bytes initializerData) → address++` [.item-kind]#internal#
+
+Deploys a UUPS proxy using the given contract as the implementation.
+
+*Parameters:*
+
+* `impl` (`address`) - Address of the contract to use as the implementation
+* `initializerData` (`bytes`) - Encoded call data of the initializer function to call during creation of the proxy, or empty if no initialization is required
+
+*Returns*
+
+* (`address`) - Proxy address
+
+[.contract-item]
+[[UnsafeUpgrades-deployTransparentProxy-address-address-bytes-]]
+==== `[.contract-item-name]#++deployTransparentProxy++#++(address impl, address initialOwner, bytes initializerData) → address++` [.item-kind]#internal#
+
+Deploys a transparent proxy using the given contract as the implementation.
+
+*Parameters:*
+
+* `impl` (`address`) - Address of the contract to use as the implementation
+* `initialOwner` (`address`) - Address to set as the owner of the ProxyAdmin contract which gets deployed by the proxy
+* `initializerData` (`bytes`) - Encoded call data of the initializer function to call during creation of the proxy, or empty if no initialization is required
+
+*Returns*
+
+* (`address`) - Proxy address
+
+[.contract-item]
+[[UnsafeUpgrades-upgradeProxy-address-address-bytes-]]
+==== `[.contract-item-name]#++upgradeProxy++#++(address proxy, address newImpl, bytes data)++` [.item-kind]#internal#
+
+Upgrades a proxy to a new implementation contract. Only supported for UUPS or transparent proxies.
+
+*Parameters:*
+
+* `proxy` (`address`) - Address of the proxy to upgrade
+* `newImpl` (`address`) - Address of the new implementation contract to upgrade to
+* `data` (`bytes`) - Encoded call data of an arbitrary function to call during the upgrade process, or empty if no function needs to be called during the upgrade
+
+[.contract-item]
+[[UnsafeUpgrades-upgradeProxy-address-address-bytes-address-]]
+==== `[.contract-item-name]#++upgradeProxy++#++(address proxy, address newImpl, bytes data, address tryCaller)++` [.item-kind]#internal#
+
+NOTE: For tests only. If broadcasting in scripts, use the `--sender <ADDRESS>` option with `forge script` instead.
+
+Upgrades a proxy to a new implementation contract. Only supported for UUPS or transparent proxies.
+
+This function provides an additional `tryCaller` parameter to test an upgrade using a specific caller address.
+Use this if you encounter `OwnableUnauthorizedAccount` errors in your tests.
+
+*Parameters:*
+
+* `proxy` (`address`) - Address of the proxy to upgrade
+* `newImpl` (`address`) - Address of the new implementation contract to upgrade to
+* `data` (`bytes`) - Encoded call data of an arbitrary function to call during the upgrade process, or empty if no function needs to be called during the upgrade
+* `tryCaller` (`address`) - Address to use as the caller of the upgrade function. This should be the address that owns the proxy or its ProxyAdmin.
+
+[.contract-item]
+[[UnsafeUpgrades-deployBeacon-address-address-]]
+==== `[.contract-item-name]#++deployBeacon++#++(address impl, address initialOwner) → address++` [.item-kind]#internal#
+
+Deploys an upgradeable beacon using the given contract as the implementation.
+
+*Parameters:*
+
+* `impl` (`address`) - Address of the contract to use as the implementation
+* `initialOwner` (`address`) - Address to set as the owner of the UpgradeableBeacon contract which gets deployed
+
+*Returns*
+
+* (`address`) - Beacon address
+
+[.contract-item]
+[[UnsafeUpgrades-upgradeBeacon-address-address-]]
+==== `[.contract-item-name]#++upgradeBeacon++#++(address beacon, address newImpl)++` [.item-kind]#internal#
+
+Upgrades a beacon to a new implementation contract.
+
+*Parameters:*
+
+* `beacon` (`address`) - Address of the beacon to upgrade
+* `newImpl` (`address`) - Address of the new implementation contract to upgrade to
+
+[.contract-item]
+[[UnsafeUpgrades-upgradeBeacon-address-address-address-]]
+==== `[.contract-item-name]#++upgradeBeacon++#++(address beacon, address newImpl, address tryCaller)++` [.item-kind]#internal#
+
+NOTE: For tests only. If broadcasting in scripts, use the `--sender <ADDRESS>` option with `forge script` instead.
+
+Upgrades a beacon to a new implementation contract.
+
+This function provides an additional `tryCaller` parameter to test an upgrade using a specific caller address.
+Use this if you encounter `OwnableUnauthorizedAccount` errors in your tests.
+
+*Parameters:*
+
+* `beacon` (`address`) - Address of the beacon to upgrade
+* `newImpl` (`address`) - Address of the new implementation contract to upgrade to
+* `tryCaller` (`address`) - Address to use as the caller of the upgrade function. This should be the address that owns the beacon.
+
+[.contract-item]
+[[UnsafeUpgrades-deployBeaconProxy-address-bytes-]]
+==== `[.contract-item-name]#++deployBeaconProxy++#++(address beacon, bytes data) → address++` [.item-kind]#internal#
+
+Deploys a beacon proxy using the given beacon and call data.
+
+*Parameters:*
+
+* `beacon` (`address`) - Address of the beacon to use
+* `data` (`bytes`) - Encoded call data of the initializer function to call during creation of the proxy, or empty if no initialization is required
+
+*Returns*
+
+* (`address`) - Proxy address
+
+[.contract-item]
+[[UnsafeUpgrades-tryPrank-address-]]
+==== `[.contract-item-name]#++tryPrank++#++(address deployer)++` [.item-kind]#modifier#
+
+Runs a function as a prank, or just runs the function normally if the prank could not be started.
 
 :deployContract: pass:normal[xref:#Defender-deployContract-string-[`++deployContract++`]]
 :deployContract: pass:normal[xref:#Defender-deployContract-string-struct-DefenderOptions-[`++deployContract++`]]

--- a/docs/modules/api/pages/api-foundry-upgrades.adoc
+++ b/docs/modules/api/pages/api-foundry-upgrades.adoc
@@ -546,14 +546,13 @@ Runs a function as a prank, or just runs the function normally if the prank coul
 import { UnsafeUpgrades } from "openzeppelin-foundry-upgrades/UnsafeUpgrades.sol";
 ```
 
-Library for deploying and managing upgradeable contracts from Forge scripts or tests, without validations.
+Library for deploying and managing upgradeable contracts from Forge tests, without validations.
 
-Requires implementation contracts to be deployed first.
-
-Works with `forge coverage`.
+Requires implementation contracts to be instantiated first. Can be used with `forge coverage`.
 Does not require `--ffi` and does not require a clean compilation before each run.
 
-WARNING: UnsafeUpgrades.sol does not validate whether your contracts are upgrade safe or whether new implementations are compatible with previous ones.
+WARNING: Not recommended for use in Forge scripts.
+UnsafeUpgrades.sol does not validate whether your contracts are upgrade safe or whether new implementations are compatible with previous ones.
 Use Upgrades.sol if you want validations to be run.
 
 [.contract-index]

--- a/docs/modules/api/pages/api-foundry-upgrades.adoc
+++ b/docs/modules/api/pages/api-foundry-upgrades.adoc
@@ -561,8 +561,9 @@ import { UnsafeUpgrades } from "openzeppelin-foundry-upgrades/UnsafeUpgrades.sol
 
 Library for deploying and managing upgradeable contracts from Forge tests, without validations.
 
-Requires implementation contracts to be instantiated first. Can be used with `forge coverage`.
+Can be used with `forge coverage`. Requires implementation contracts to be instantiated first.
 Does not require `--ffi` and does not require a clean compilation before each run.
+
 Not supported for OpenZeppelin Defender deployments.
 
 WARNING: Not recommended for use in Forge scripts.

--- a/docs/modules/pages/foundry-upgrades.adoc
+++ b/docs/modules/pages/foundry-upgrades.adoc
@@ -195,7 +195,7 @@ address proxy = Upgrades.deployUUPSProxy(
 );
 ```
 
-WARNING: xref:api-foundry-upgrades.adoc#UnsafeUpgrades[`UnsafeUpgrades`] does not validate whether your contracts are upgrade safe or whether new implementations are compatible with previous ones. Ensure you run validations before any actual deployments or upgrades, such as by using xref:api-foundry-upgrades.adoc#Upgrades[`Upgrades`] in scripts.
+WARNING: xref:api-foundry-upgrades.adoc#UnsafeUpgrades[`UnsafeUpgrades`] is not recommended for use in Forge scripts. It does not validate whether your contracts are upgrade safe or whether new implementations are compatible with previous ones. Ensure you run validations before any actual deployments or upgrades, such as by using xref:api-foundry-upgrades.adoc#Upgrades[`Upgrades`] in scripts.
 
 == API
 

--- a/docs/modules/pages/foundry-upgrades.adoc
+++ b/docs/modules/pages/foundry-upgrades.adoc
@@ -184,6 +184,19 @@ IMPORTANT: Include the `--sender <ADDRESS>` flag for the `forge script` command 
 
 NOTE: Include the `--verify` flag for the `forge script` command if you want to verify source code such as on Etherscan. This will verify your implementation contracts along with any proxy contracts as part of the deployment.
 
+=== Coverage Testing
+
+To enable code coverage reports with `forge coverage`, use the following deployment pattern in your tests: instantiate your implementation contracts directly and use xref:api-foundry-upgrades.adoc#UnsafeUpgrades[`UnsafeUpgrades`]. For example:
+```solidity
+address implementation = address(new MyContract());
+address proxy = Upgrades.deployUUPSProxy(
+    implementation,
+    abi.encodeCall(MyContract.initialize, ("arguments for the initialize function"))
+);
+```
+
+WARNING: xref:api-foundry-upgrades.adoc#UnsafeUpgrades[`UnsafeUpgrades`] does not validate whether your contracts are upgrade safe or whether new implementations are compatible with previous ones. Ensure you run validations before any actual deployments or upgrades, such as by using xref:api-foundry-upgrades.adoc#Upgrades[`Upgrades`] in scripts.
+
 == API
 
 See xref:api-foundry-upgrades.adoc[Foundry Upgrades API] for the full API documentation.

--- a/docs/modules/pages/foundry-upgrades.adoc
+++ b/docs/modules/pages/foundry-upgrades.adoc
@@ -63,7 +63,7 @@ extra_output = ["storageLayout"]
 
 4. Run `forge clean` before running your Foundry script or tests, or include the `--force` option when running `forge script` or `forge test`.
 
-If you do not want to run upgrade safety checks, you can skip the above steps and use the `unsafeSkipAllChecks` option when calling the library's functions. Note that this is a dangerous option meant to be used as a last resort.
+If you do not want to run upgrade safety checks, you can skip the above steps and use the xref:api-foundry-upgrades.adoc#Options[`unsafeSkipAllChecks` option] when calling the `Upgrades` library's functions, or use xref:api-foundry-upgrades.adoc#UnsafeUpgrades[`UnsafeUpgrades`] instead. Note that these are dangerous options meant to be used as a last resort.
 
 === Output directory configuration
 

--- a/src/README.adoc
+++ b/src/README.adoc
@@ -12,6 +12,6 @@ The following options can be used with some of the below functions. See https://
 
 {{Upgrades}}
 
-== Foundry Defender
+{{UnsafeUpgrades}}
 
 {{Defender}}

--- a/src/UnsafeUpgrades.sol
+++ b/src/UnsafeUpgrades.sol
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {ERC1967Utils} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
+import {ITransparentUpgradeableProxy, TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {UpgradeableBeacon} from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import {BeaconProxy} from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
+
+import {Vm} from "forge-std/Vm.sol";
+import {Utils} from "./internal/Utils.sol";
+import {Upgrades} from "./Upgrades.sol";
+
+/**
+ * @dev Library for deploying and managing upgradeable contracts from Forge scripts or tests, without any validations.
+ *
+ * Requires implementation contracts to be deployed before calling its functions.
+ *
+ * Works with `forge coverage`.
+ * Does not require `--ffi` and does not require a clean compilation before each run.
+ *
+ * WARNING: This library does not validate whether your contracts are upgrade safe or whether new implementations are compatible with previous ones.
+ * Use Upgrades.sol if you want validations to be run.
+ */
+library UnsafeUpgrades {
+    /**
+     * @dev Deploys a UUPS proxy using the given contract as the implementation.
+     *
+     * @param impl Address of the contract to use as the implementation
+     * @param initializerData Encoded call data of the initializer function to call during creation of the proxy, or empty if no initialization is required
+     * @return Proxy address
+     */
+    function deployUUPSProxy(address impl, bytes memory initializerData) internal returns (address) {
+        return address(new ERC1967Proxy(impl, initializerData));
+    }
+
+    /**
+     * @dev Deploys a transparent proxy using the given contract as the implementation.
+     *
+     * @param impl Address of the contract to use as the implementation
+     * @param initialOwner Address to set as the owner of the ProxyAdmin contract which gets deployed by the proxy
+     * @param initializerData Encoded call data of the initializer function to call during creation of the proxy, or empty if no initialization is required
+     * @return Proxy address
+     */
+    function deployTransparentProxy(
+        address impl,
+        address initialOwner,
+        bytes memory initializerData
+    ) internal returns (address) {
+        return address(new TransparentUpgradeableProxy(impl, initialOwner, initializerData));
+    }
+
+    /**
+     * @dev Upgrades a proxy to a new implementation contract. Only supported for UUPS or transparent proxies.
+     *
+     * @param proxy Address of the proxy to upgrade
+     * @param newImpl Address of the new implementation contract to upgrade to
+     * @param data Encoded call data of an arbitrary function to call during the upgrade process, or empty if no function needs to be called during the upgrade
+     */
+    function upgradeProxy(address proxy, address newImpl, bytes memory data) internal {
+        Vm vm = Vm(Utils.CHEATCODE_ADDRESS);
+
+        bytes32 adminSlot = vm.load(proxy, ERC1967Utils.ADMIN_SLOT);
+        if (adminSlot == bytes32(0)) {
+            // No admin contract: upgrade directly using interface
+            ITransparentUpgradeableProxy(proxy).upgradeToAndCall(newImpl, data);
+        } else {
+            ProxyAdmin admin = ProxyAdmin(address(uint160(uint256(adminSlot))));
+            admin.upgradeAndCall(ITransparentUpgradeableProxy(proxy), newImpl, data);
+        }
+    }
+
+    /**
+     * @notice For tests only. If broadcasting in scripts, use the `--sender <ADDRESS>` option with `forge script` instead.
+     *
+     * @dev Upgrades a proxy to a new implementation contract. Only supported for UUPS or transparent proxies.
+     *
+     * This function provides an additional `tryCaller` parameter to test an upgrade using a specific caller address.
+     * Use this if you encounter `OwnableUnauthorizedAccount` errors in your tests.
+     *
+     * @param proxy Address of the proxy to upgrade
+     * @param newImpl Address of the new implementation contract to upgrade to
+     * @param data Encoded call data of an arbitrary function to call during the upgrade process, or empty if no function needs to be called during the upgrade
+     * @param tryCaller Address to use as the caller of the upgrade function. This should be the address that owns the proxy or its ProxyAdmin.
+     */
+    function upgradeProxy(
+        address proxy,
+        address newImpl,
+        bytes memory data,
+        address tryCaller
+    ) internal tryPrank(tryCaller) {
+        upgradeProxy(proxy, newImpl, data);
+    }
+
+    /**
+     * @dev Deploys an upgradeable beacon using the given contract as the implementation.
+     *
+     * @param impl Address of the contract to use as the implementation
+     * @param initialOwner Address to set as the owner of the UpgradeableBeacon contract which gets deployed
+     * @return Beacon address
+     */
+    function deployBeacon(address impl, address initialOwner) internal returns (address) {
+        return address(new UpgradeableBeacon(impl, initialOwner));
+    }
+
+    /**
+     * @dev Upgrades a beacon to a new implementation contract.
+     *
+     * @param beacon Address of the beacon to upgrade
+     * @param newImpl Address of the new implementation contract to upgrade to
+     */
+    function upgradeBeacon(address beacon, address newImpl) internal {
+        UpgradeableBeacon(beacon).upgradeTo(newImpl);
+    }
+
+    /**
+     * @notice For tests only. If broadcasting in scripts, use the `--sender <ADDRESS>` option with `forge script` instead.
+     *
+     * @dev Upgrades a beacon to a new implementation contract.
+     *
+     * This function provides an additional `tryCaller` parameter to test an upgrade using a specific caller address.
+     * Use this if you encounter `OwnableUnauthorizedAccount` errors in your tests.
+     *
+     * @param beacon Address of the beacon to upgrade
+     * @param newImpl Address of the new implementation contract to upgrade to
+     * @param tryCaller Address to use as the caller of the upgrade function. This should be the address that owns the beacon.
+     */
+    function upgradeBeacon(address beacon, address newImpl, address tryCaller) internal tryPrank(tryCaller) {
+        upgradeBeacon(beacon, newImpl);
+    }
+
+    /**
+     * @dev Deploys a beacon proxy using the given beacon and call data.
+     *
+     * @param beacon Address of the beacon to use
+     * @param data Encoded call data of the initializer function to call during creation of the proxy, or empty if no initialization is required
+     * @return Proxy address
+     */
+    function deployBeaconProxy(address beacon, bytes memory data) internal returns (address) {
+        return address(new BeaconProxy(beacon, data));
+    }
+
+    /**
+     * @notice For tests only. If broadcasting in scripts, use the `--sender <ADDRESS>` option with `forge script` instead.
+     *
+     * @dev Runs a function as a prank, or just runs the function normally if the prank could not be started.
+     */
+    modifier tryPrank(address deployer) {
+        Vm vm = Vm(Utils.CHEATCODE_ADDRESS);
+
+        try vm.startPrank(deployer) {
+            _;
+            vm.stopPrank();
+        } catch {
+            _;
+        }
+    }
+}

--- a/src/UnsafeUpgrades.sol
+++ b/src/UnsafeUpgrades.sol
@@ -17,6 +17,7 @@ import {Upgrades} from "./Upgrades.sol";
  *
  * Requires implementation contracts to be instantiated first. Can be used with `forge coverage`.
  * Does not require `--ffi` and does not require a clean compilation before each run.
+ * Not supported for OpenZeppelin Defender deployments.
  *
  * WARNING: Not recommended for use in Forge scripts.
  * UnsafeUpgrades.sol does not validate whether your contracts are upgrade safe or whether new implementations are compatible with previous ones.

--- a/src/UnsafeUpgrades.sol
+++ b/src/UnsafeUpgrades.sol
@@ -13,14 +13,14 @@ import {Utils} from "./internal/Utils.sol";
 import {Upgrades} from "./Upgrades.sol";
 
 /**
- * @dev Library for deploying and managing upgradeable contracts from Forge scripts or tests, without any validations.
+ * @dev Library for deploying and managing upgradeable contracts from Forge scripts or tests, without validations.
  *
- * Requires implementation contracts to be deployed before calling its functions.
+ * Requires implementation contracts to be deployed first.
  *
  * Works with `forge coverage`.
  * Does not require `--ffi` and does not require a clean compilation before each run.
  *
- * WARNING: This library does not validate whether your contracts are upgrade safe or whether new implementations are compatible with previous ones.
+ * WARNING: UnsafeUpgrades.sol does not validate whether your contracts are upgrade safe or whether new implementations are compatible with previous ones.
  * Use Upgrades.sol if you want validations to be run.
  */
 library UnsafeUpgrades {

--- a/src/UnsafeUpgrades.sol
+++ b/src/UnsafeUpgrades.sol
@@ -15,8 +15,9 @@ import {Upgrades} from "./Upgrades.sol";
 /**
  * @dev Library for deploying and managing upgradeable contracts from Forge tests, without validations.
  *
- * Requires implementation contracts to be instantiated first. Can be used with `forge coverage`.
+ * Can be used with `forge coverage`. Requires implementation contracts to be instantiated first.
  * Does not require `--ffi` and does not require a clean compilation before each run.
+ *
  * Not supported for OpenZeppelin Defender deployments.
  *
  * WARNING: Not recommended for use in Forge scripts.

--- a/src/UnsafeUpgrades.sol
+++ b/src/UnsafeUpgrades.sol
@@ -13,14 +13,13 @@ import {Utils} from "./internal/Utils.sol";
 import {Upgrades} from "./Upgrades.sol";
 
 /**
- * @dev Library for deploying and managing upgradeable contracts from Forge scripts or tests, without validations.
+ * @dev Library for deploying and managing upgradeable contracts from Forge tests, without validations.
  *
- * Requires implementation contracts to be deployed first.
- *
- * Works with `forge coverage`.
+ * Requires implementation contracts to be instantiated first. Can be used with `forge coverage`.
  * Does not require `--ffi` and does not require a clean compilation before each run.
  *
- * WARNING: UnsafeUpgrades.sol does not validate whether your contracts are upgrade safe or whether new implementations are compatible with previous ones.
+ * WARNING: Not recommended for use in Forge scripts.
+ * UnsafeUpgrades.sol does not validate whether your contracts are upgrade safe or whether new implementations are compatible with previous ones.
  * Use Upgrades.sol if you want validations to be run.
  */
 library UnsafeUpgrades {

--- a/src/UnsafeUpgrades.sol
+++ b/src/UnsafeUpgrades.sol
@@ -10,7 +10,6 @@ import {BeaconProxy} from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol"
 
 import {Vm} from "forge-std/Vm.sol";
 import {Utils} from "./internal/Utils.sol";
-import {Upgrades} from "./Upgrades.sol";
 
 /**
  * @dev Library for deploying and managing upgradeable contracts from Forge tests, without validations.

--- a/src/Upgrades.sol
+++ b/src/Upgrades.sol
@@ -106,7 +106,7 @@ library Upgrades {
     function upgradeProxy(address proxy, string memory contractName, bytes memory data, Options memory opts) internal {
         address newImpl = prepareUpgrade(contractName, opts);
 
-        Vm vm = Vm(Utils.CHEATCODE_ADDRESS);
+        Vm vm = Vm(CHEATCODE_ADDRESS);
 
         bytes32 adminSlot = vm.load(proxy, ERC1967Utils.ADMIN_SLOT);
         if (adminSlot == bytes32(0)) {
@@ -364,7 +364,7 @@ library Upgrades {
      * @return Admin address
      */
     function getAdminAddress(address proxy) internal view returns (address) {
-        Vm vm = Vm(Utils.CHEATCODE_ADDRESS);
+        Vm vm = Vm(CHEATCODE_ADDRESS);
 
         bytes32 adminSlot = vm.load(proxy, ERC1967Utils.ADMIN_SLOT);
         return address(uint160(uint256(adminSlot)));
@@ -377,7 +377,7 @@ library Upgrades {
      * @return Implementation address
      */
     function getImplementationAddress(address proxy) internal view returns (address) {
-        Vm vm = Vm(Utils.CHEATCODE_ADDRESS);
+        Vm vm = Vm(CHEATCODE_ADDRESS);
 
         bytes32 implSlot = vm.load(proxy, ERC1967Utils.IMPLEMENTATION_SLOT);
         return address(uint160(uint256(implSlot)));
@@ -390,7 +390,7 @@ library Upgrades {
      * @return Beacon address
      */
     function getBeaconAddress(address proxy) internal view returns (address) {
-        Vm vm = Vm(Utils.CHEATCODE_ADDRESS);
+        Vm vm = Vm(CHEATCODE_ADDRESS);
 
         bytes32 beaconSlot = vm.load(proxy, ERC1967Utils.BEACON_SLOT);
         return address(uint160(uint256(beaconSlot)));
@@ -402,7 +402,7 @@ library Upgrades {
      * @dev Runs a function as a prank, or just runs the function normally if the prank could not be started.
      */
     modifier tryPrank(address deployer) {
-        Vm vm = Vm(Utils.CHEATCODE_ADDRESS);
+        Vm vm = Vm(CHEATCODE_ADDRESS);
 
         try vm.startPrank(deployer) {
             _;
@@ -413,6 +413,7 @@ library Upgrades {
     }
 
     using strings for *;
+    address constant CHEATCODE_ADDRESS = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D;
 
     function _validate(string memory contractName, Options memory opts, bool requireReference) private {
         if (opts.unsafeSkipAllChecks) {
@@ -491,7 +492,7 @@ library Upgrades {
         if (opts.defender.useDefenderDeploy) {
             return DefenderDeploy.deploy(contractName, constructorData, opts.defender);
         } else {
-            bytes memory creationCode = Vm(Utils.CHEATCODE_ADDRESS).getCode(contractName);
+            bytes memory creationCode = Vm(CHEATCODE_ADDRESS).getCode(contractName);
             address deployedAddress = _deployFromBytecode(abi.encodePacked(creationCode, constructorData));
             if (deployedAddress == address(0)) {
                 revert(

--- a/src/Upgrades.sol
+++ b/src/Upgrades.sol
@@ -18,7 +18,7 @@ import {Utils} from "./internal/Utils.sol";
 import {DefenderDeploy} from "./internal/DefenderDeploy.sol";
 
 /**
- * @dev Library for deploying and managing upgradeable contracts from Forge scripts or tests.
+ * @dev Library for deploying and managing upgradeable contracts from Forge scripts or tests, with validations that run before each deployment.
  */
 library Upgrades {
     /**

--- a/src/Upgrades.sol
+++ b/src/Upgrades.sol
@@ -106,7 +106,7 @@ library Upgrades {
     function upgradeProxy(address proxy, string memory contractName, bytes memory data, Options memory opts) internal {
         address newImpl = prepareUpgrade(contractName, opts);
 
-        Vm vm = Vm(CHEATCODE_ADDRESS);
+        Vm vm = Vm(Utils.CHEATCODE_ADDRESS);
 
         bytes32 adminSlot = vm.load(proxy, ERC1967Utils.ADMIN_SLOT);
         if (adminSlot == bytes32(0)) {
@@ -364,7 +364,7 @@ library Upgrades {
      * @return Admin address
      */
     function getAdminAddress(address proxy) internal view returns (address) {
-        Vm vm = Vm(CHEATCODE_ADDRESS);
+        Vm vm = Vm(Utils.CHEATCODE_ADDRESS);
 
         bytes32 adminSlot = vm.load(proxy, ERC1967Utils.ADMIN_SLOT);
         return address(uint160(uint256(adminSlot)));
@@ -377,7 +377,7 @@ library Upgrades {
      * @return Implementation address
      */
     function getImplementationAddress(address proxy) internal view returns (address) {
-        Vm vm = Vm(CHEATCODE_ADDRESS);
+        Vm vm = Vm(Utils.CHEATCODE_ADDRESS);
 
         bytes32 implSlot = vm.load(proxy, ERC1967Utils.IMPLEMENTATION_SLOT);
         return address(uint160(uint256(implSlot)));
@@ -390,7 +390,7 @@ library Upgrades {
      * @return Beacon address
      */
     function getBeaconAddress(address proxy) internal view returns (address) {
-        Vm vm = Vm(CHEATCODE_ADDRESS);
+        Vm vm = Vm(Utils.CHEATCODE_ADDRESS);
 
         bytes32 beaconSlot = vm.load(proxy, ERC1967Utils.BEACON_SLOT);
         return address(uint160(uint256(beaconSlot)));
@@ -402,7 +402,7 @@ library Upgrades {
      * @dev Runs a function as a prank, or just runs the function normally if the prank could not be started.
      */
     modifier tryPrank(address deployer) {
-        Vm vm = Vm(CHEATCODE_ADDRESS);
+        Vm vm = Vm(Utils.CHEATCODE_ADDRESS);
 
         try vm.startPrank(deployer) {
             _;
@@ -413,7 +413,6 @@ library Upgrades {
     }
 
     using strings for *;
-    address constant CHEATCODE_ADDRESS = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D;
 
     function _validate(string memory contractName, Options memory opts, bool requireReference) private {
         if (opts.unsafeSkipAllChecks) {
@@ -492,7 +491,7 @@ library Upgrades {
         if (opts.defender.useDefenderDeploy) {
             return DefenderDeploy.deploy(contractName, constructorData, opts.defender);
         } else {
-            bytes memory creationCode = Vm(CHEATCODE_ADDRESS).getCode(contractName);
+            bytes memory creationCode = Vm(Utils.CHEATCODE_ADDRESS).getCode(contractName);
             address deployedAddress = _deployFromBytecode(abi.encodePacked(creationCode, constructorData));
             if (deployedAddress == address(0)) {
                 revert(

--- a/test/UnsafeUpgrades.t.sol
+++ b/test/UnsafeUpgrades.t.sol
@@ -23,7 +23,10 @@ contract UnsafeUpgradesTest is Test {
     address constant CHEATCODE_ADDRESS = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D;
 
     function testUUPS() public {
-        address proxy = UnsafeUpgrades.deployUUPSProxy(address(new GreeterProxiable()), abi.encodeCall(Greeter.initialize, ("hello")));
+        address proxy = UnsafeUpgrades.deployUUPSProxy(
+            address(new GreeterProxiable()),
+            abi.encodeCall(Greeter.initialize, ("hello"))
+        );
         Greeter instance = Greeter(proxy);
         address implAddressV1 = Upgrades.getImplementationAddress(proxy);
 
@@ -55,7 +58,12 @@ contract UnsafeUpgradesTest is Test {
 
         assertEq(instance.greeting(), "hello");
 
-        UnsafeUpgrades.upgradeProxy(proxy, address(new GreeterV2()), abi.encodeCall(GreeterV2.resetGreeting, ()), msg.sender);
+        UnsafeUpgrades.upgradeProxy(
+            proxy,
+            address(new GreeterV2()),
+            abi.encodeCall(GreeterV2.resetGreeting, ()),
+            msg.sender
+        );
         address implAddressV2 = Upgrades.getImplementationAddress(proxy);
 
         assertEq(Upgrades.getAdminAddress(proxy), adminAddress);
@@ -92,7 +100,11 @@ contract UnsafeUpgradesTest is Test {
 
         Vm vm = Vm(CHEATCODE_ADDRESS);
         vm.startPrank(msg.sender);
-        UnsafeUpgrades.upgradeProxy(proxy, address(new GreeterV2Proxiable()), abi.encodeCall(GreeterV2Proxiable.resetGreeting, ()));
+        UnsafeUpgrades.upgradeProxy(
+            proxy,
+            address(new GreeterV2Proxiable()),
+            abi.encodeCall(GreeterV2Proxiable.resetGreeting, ())
+        );
         vm.stopPrank();
     }
 
@@ -107,7 +119,7 @@ contract UnsafeUpgradesTest is Test {
 
     function testWithConstructor() public {
         address proxy = UnsafeUpgrades.deployTransparentProxy(
-            address (new WithConstructor(123)),
+            address(new WithConstructor(123)),
             msg.sender,
             abi.encodeCall(WithConstructor.initialize, (456))
         );
@@ -116,7 +128,7 @@ contract UnsafeUpgradesTest is Test {
     }
 
     function testNoInitializer() public {
-        address proxy = UnsafeUpgrades.deployTransparentProxy(address (new WithConstructor(123)), msg.sender, "");
+        address proxy = UnsafeUpgrades.deployTransparentProxy(address(new WithConstructor(123)), msg.sender, "");
         assertEq(WithConstructor(proxy).a(), 123);
     }
 }

--- a/test/UnsafeUpgrades.t.sol
+++ b/test/UnsafeUpgrades.t.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
+
+import {Upgrades} from "openzeppelin-foundry-upgrades/Upgrades.sol";
+import {UnsafeUpgrades} from "openzeppelin-foundry-upgrades/UnsafeUpgrades.sol";
+
+import {Proxy} from "@openzeppelin/contracts/proxy/Proxy.sol";
+import {IBeacon} from "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
+
+import {Greeter} from "./contracts/Greeter.sol";
+import {GreeterProxiable} from "./contracts/GreeterProxiable.sol";
+import {GreeterV2} from "./contracts/GreeterV2.sol";
+import {GreeterV2Proxiable} from "./contracts/GreeterV2Proxiable.sol";
+import {WithConstructor, NoInitializer} from "./contracts/WithConstructor.sol";
+
+/**
+ * @dev Tests for the UnsafeUpgrades library.
+ */
+contract UnsafeUpgradesTest is Test {
+    address constant CHEATCODE_ADDRESS = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D;
+
+    function testUUPS() public {
+        address proxy = UnsafeUpgrades.deployUUPSProxy(address(new GreeterProxiable()), abi.encodeCall(Greeter.initialize, ("hello")));
+        Greeter instance = Greeter(proxy);
+        address implAddressV1 = Upgrades.getImplementationAddress(proxy);
+
+        assertEq(instance.greeting(), "hello");
+
+        UnsafeUpgrades.upgradeProxy(
+            proxy,
+            address(new GreeterV2Proxiable()),
+            abi.encodeCall(GreeterV2Proxiable.resetGreeting, ()),
+            msg.sender
+        );
+        address implAddressV2 = Upgrades.getImplementationAddress(proxy);
+
+        assertEq(instance.greeting(), "resetted");
+        assertFalse(implAddressV2 == implAddressV1);
+    }
+
+    function testTransparent() public {
+        address proxy = UnsafeUpgrades.deployTransparentProxy(
+            address(new Greeter()),
+            msg.sender,
+            abi.encodeCall(Greeter.initialize, ("hello"))
+        );
+        Greeter instance = Greeter(proxy);
+        address implAddressV1 = Upgrades.getImplementationAddress(proxy);
+        address adminAddress = Upgrades.getAdminAddress(proxy);
+
+        assertFalse(adminAddress == address(0));
+
+        assertEq(instance.greeting(), "hello");
+
+        UnsafeUpgrades.upgradeProxy(proxy, address(new GreeterV2()), abi.encodeCall(GreeterV2.resetGreeting, ()), msg.sender);
+        address implAddressV2 = Upgrades.getImplementationAddress(proxy);
+
+        assertEq(Upgrades.getAdminAddress(proxy), adminAddress);
+
+        assertEq(instance.greeting(), "resetted");
+        assertFalse(implAddressV2 == implAddressV1);
+    }
+
+    function testBeacon() public {
+        address beacon = UnsafeUpgrades.deployBeacon(address(new Greeter()), msg.sender);
+        address implAddressV1 = IBeacon(beacon).implementation();
+
+        address proxy = UnsafeUpgrades.deployBeaconProxy(beacon, abi.encodeCall(Greeter.initialize, ("hello")));
+        Greeter instance = Greeter(proxy);
+
+        assertEq(Upgrades.getBeaconAddress(proxy), beacon);
+
+        assertEq(instance.greeting(), "hello");
+
+        UnsafeUpgrades.upgradeBeacon(beacon, address(new GreeterV2()), msg.sender);
+        address implAddressV2 = IBeacon(beacon).implementation();
+
+        GreeterV2(address(instance)).resetGreeting();
+
+        assertEq(instance.greeting(), "resetted");
+        assertFalse(implAddressV2 == implAddressV1);
+    }
+
+    function testUpgradeProxyWithoutCaller() public {
+        address proxy = UnsafeUpgrades.deployUUPSProxy(
+            address(new GreeterProxiable()),
+            abi.encodeCall(GreeterProxiable.initialize, ("hello"))
+        );
+
+        Vm vm = Vm(CHEATCODE_ADDRESS);
+        vm.startPrank(msg.sender);
+        UnsafeUpgrades.upgradeProxy(proxy, address(new GreeterV2Proxiable()), abi.encodeCall(GreeterV2Proxiable.resetGreeting, ()));
+        vm.stopPrank();
+    }
+
+    function testUpgradeBeaconWithoutCaller() public {
+        address beacon = UnsafeUpgrades.deployBeacon(address(new Greeter()), msg.sender);
+
+        Vm vm = Vm(CHEATCODE_ADDRESS);
+        vm.startPrank(msg.sender);
+        UnsafeUpgrades.upgradeBeacon(beacon, address(new GreeterV2()));
+        vm.stopPrank();
+    }
+
+    function testWithConstructor() public {
+        address proxy = UnsafeUpgrades.deployTransparentProxy(
+            address (new WithConstructor(123)),
+            msg.sender,
+            abi.encodeCall(WithConstructor.initialize, (456))
+        );
+        assertEq(WithConstructor(proxy).a(), 123);
+        assertEq(WithConstructor(proxy).b(), 456);
+    }
+
+    function testNoInitializer() public {
+        address proxy = UnsafeUpgrades.deployTransparentProxy(address (new WithConstructor(123)), msg.sender, "");
+        assertEq(WithConstructor(proxy).a(), 123);
+    }
+}


### PR DESCRIPTION
Fixes #44 
Fixes #34 

`forge coverage` does not work with Upgrades.sol because that library performs deployments using artifact bytecode instead of instantiating contracts directly.  It needs to use bytecode for the reasons described in https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/issues/34#issuecomment-2025693908

This PR adds a new UnsafeUpgrades.sol which works with `forge coverage`.

Note that UnsafeUpgrades does not perform any upgrade safety validations, so is not recommended for use with Forge scripts.