### PR TITLE
Fix upgrade interface version detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.1 (2024-05-21)
+
+- Fix upgrade interface version detection in `upgradeProxy` function. ([#53](https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/pull/53))
+
 ## 0.3.0 (2024-05-14)
 
 - Adds library variations to support `forge coverage` or upgrade existing deployments using OpenZeppelin Contracts v4. ([#50](https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/pull/50))

--- a/src/internal/Core.sol
+++ b/src/internal/Core.sol
@@ -303,7 +303,7 @@ library Core {
     using strings for *;
 
     function _getUpgradeInterfaceVersion(address addr) private returns (string memory) {
-        (bool success, bytes memory returndata) = addr.call(abi.encodeWithSignature("getUpgradeInterfaceVersion()"));
+        (bool success, bytes memory returndata) = addr.call(abi.encodeWithSignature("UPGRADE_INTERFACE_VERSION()"));
         if (success) {
             return abi.decode(returndata, (string));
         } else {

--- a/test/UnsafeUpgrades.t.sol
+++ b/test/UnsafeUpgrades.t.sol
@@ -40,6 +40,24 @@ contract UnsafeUpgradesTest is Test {
         assertFalse(implAddressV2 == implAddressV1);
     }
 
+    function testUUPS_upgradeWithoutData() public {
+        address proxy = UnsafeUpgrades.deployUUPSProxy(
+            address(new GreeterProxiable()),
+            abi.encodeCall(Greeter.initialize, (msg.sender, "hello"))
+        );
+        address implAddressV1 = UnsafeUpgrades.getImplementationAddress(proxy);
+
+        UnsafeUpgrades.upgradeProxy(
+            proxy,
+            address(new GreeterV2Proxiable()),
+            "",
+            msg.sender
+        );
+        address implAddressV2 = UnsafeUpgrades.getImplementationAddress(proxy);
+
+        assertFalse(implAddressV2 == implAddressV1);
+    }
+
     function testTransparent() public {
         address proxy = UnsafeUpgrades.deployTransparentProxy(
             address(new Greeter()),
@@ -65,6 +83,30 @@ contract UnsafeUpgradesTest is Test {
         assertEq(UnsafeUpgrades.getAdminAddress(proxy), adminAddress);
 
         assertEq(instance.greeting(), "resetted");
+        assertFalse(implAddressV2 == implAddressV1);
+    }
+
+    function testTransparent_upgradeWithoutData() public {
+        address proxy = UnsafeUpgrades.deployTransparentProxy(
+            address(new Greeter()),
+            msg.sender,
+            abi.encodeCall(Greeter.initialize, (msg.sender, "hello"))
+        );
+        address implAddressV1 = UnsafeUpgrades.getImplementationAddress(proxy);
+        address adminAddress = UnsafeUpgrades.getAdminAddress(proxy);
+
+        assertFalse(adminAddress == address(0));
+
+        UnsafeUpgrades.upgradeProxy(
+            proxy,
+            address(new GreeterV2()),
+            "",
+            msg.sender
+        );
+        address implAddressV2 = UnsafeUpgrades.getImplementationAddress(proxy);
+
+        assertEq(UnsafeUpgrades.getAdminAddress(proxy), adminAddress);
+
         assertFalse(implAddressV2 == implAddressV1);
     }
 

--- a/test/UnsafeUpgrades.t.sol
+++ b/test/UnsafeUpgrades.t.sol
@@ -47,12 +47,7 @@ contract UnsafeUpgradesTest is Test {
         );
         address implAddressV1 = UnsafeUpgrades.getImplementationAddress(proxy);
 
-        UnsafeUpgrades.upgradeProxy(
-            proxy,
-            address(new GreeterV2Proxiable()),
-            "",
-            msg.sender
-        );
+        UnsafeUpgrades.upgradeProxy(proxy, address(new GreeterV2Proxiable()), "", msg.sender);
         address implAddressV2 = UnsafeUpgrades.getImplementationAddress(proxy);
 
         assertFalse(implAddressV2 == implAddressV1);
@@ -97,12 +92,7 @@ contract UnsafeUpgradesTest is Test {
 
         assertFalse(adminAddress == address(0));
 
-        UnsafeUpgrades.upgradeProxy(
-            proxy,
-            address(new GreeterV2()),
-            "",
-            msg.sender
-        );
+        UnsafeUpgrades.upgradeProxy(proxy, address(new GreeterV2()), "", msg.sender);
         address implAddressV2 = UnsafeUpgrades.getImplementationAddress(proxy);
 
         assertEq(UnsafeUpgrades.getAdminAddress(proxy), adminAddress);

--- a/test/Upgrades.t.sol
+++ b/test/Upgrades.t.sol
@@ -42,6 +42,24 @@ contract UpgradesTest is Test {
         assertFalse(implAddressV2 == implAddressV1);
     }
 
+    function testUUPS_upgradeWithoutData() public {
+        address proxy = Upgrades.deployUUPSProxy(
+            "GreeterProxiable.sol",
+            abi.encodeCall(Greeter.initialize, (msg.sender, "hello"))
+        );
+        address implAddressV1 = Upgrades.getImplementationAddress(proxy);
+
+        Upgrades.upgradeProxy(
+            proxy,
+            "GreeterV2Proxiable.sol",
+            "",
+            msg.sender
+        );
+        address implAddressV2 = Upgrades.getImplementationAddress(proxy);
+
+        assertFalse(implAddressV2 == implAddressV1);
+    }
+
     function testTransparent() public {
         address proxy = Upgrades.deployTransparentProxy(
             "Greeter.sol",
@@ -62,6 +80,25 @@ contract UpgradesTest is Test {
         assertEq(Upgrades.getAdminAddress(proxy), adminAddress);
 
         assertEq(instance.greeting(), "resetted");
+        assertFalse(implAddressV2 == implAddressV1);
+    }
+
+    function testTransparent_upgradeWithoutData() public {
+        address proxy = Upgrades.deployTransparentProxy(
+            "Greeter.sol",
+            msg.sender,
+            abi.encodeCall(Greeter.initialize, (msg.sender, "hello"))
+        );
+        address implAddressV1 = Upgrades.getImplementationAddress(proxy);
+        address adminAddress = Upgrades.getAdminAddress(proxy);
+
+        assertFalse(adminAddress == address(0));
+
+        Upgrades.upgradeProxy(proxy, "GreeterV2.sol", "", msg.sender);
+        address implAddressV2 = Upgrades.getImplementationAddress(proxy);
+
+        assertEq(Upgrades.getAdminAddress(proxy), adminAddress);
+
         assertFalse(implAddressV2 == implAddressV1);
     }
 

--- a/test/Upgrades.t.sol
+++ b/test/Upgrades.t.sol
@@ -49,12 +49,7 @@ contract UpgradesTest is Test {
         );
         address implAddressV1 = Upgrades.getImplementationAddress(proxy);
 
-        Upgrades.upgradeProxy(
-            proxy,
-            "GreeterV2Proxiable.sol",
-            "",
-            msg.sender
-        );
+        Upgrades.upgradeProxy(proxy, "GreeterV2Proxiable.sol", "", msg.sender);
         address implAddressV2 = Upgrades.getImplementationAddress(proxy);
 
         assertFalse(implAddressV2 == implAddressV1);


### PR DESCRIPTION
Before:

```
    ├─ [5536] 0x526997541edA13B59320DF54f11dD5d3BD7b6CdD::be1c44ea()
    │   ├─ [740] 0x6a16cAF9831caDBd02Df2C43176214e7308f28b0::be1c44ea() [delegatecall]
    │   │   └─ ← [Revert]
    │   └─ ← [Revert]
    ├─ [5539] 0x526997541edA13B59320DF54f11dD5d3BD7b6CdD::upgradeTo(ImplementationV2: [0x74C98f4CC839B4660c90d7c1FacF3FdF9d651D17])
    │   ├─ [740] 0x6a16cAF9831caDBd02Df2C43176214e7308f28b0::upgradeTo(ImplementationV2: [0x74C98f4CC839B4660c90d7c1FacF3FdF9d651D17]) [delegatecall]
    │   │   └─ ← [Revert] EvmError: Revert
    │   └─ ← [Revert] EvmError: Revert
    └─ ← [Revert] EvmError: Revert

Error:
script failed: <empty revert data>
```

After:
```
  [5816] 0x9513774775cd8cA66D04B816D6Dc5e9F2025707a::UPGRADE_INTERFACE_VERSION()
    ├─ [1012] 0x74C98f4CC839B4660c90d7c1FacF3FdF9d651D17::UPGRADE_INTERFACE_VERSION() [delegatecall]
    │   └─ ← [Return] "5.0.0"
    └─ ← [Return] "5.0.0"

  [15617] 0x9513774775cd8cA66D04B816D6Dc5e9F2025707a::upgradeToAndCall(ImplementationV2: [0xCaFe8cdd71603b9B50bD5844ba2d7b9cEe82A3E9], 0x)
    ├─ [10810] 0x74C98f4CC839B4660c90d7c1FacF3FdF9d651D17::upgradeToAndCall(ImplementationV2: [0xCaFe8cdd71603b9B50bD5844ba2d7b9cEe82A3E9], 0x) [delegatecall]
    │   ├─ [396] ImplementationV2::proxiableUUID() [staticcall]
    │   │   └─ ← [Return] 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc
    │   ├─ emit Upgraded(implementation: ImplementationV2: [0xCaFe8cdd71603b9B50bD5844ba2d7b9cEe82A3E9])
    │   └─ ← [Stop]
    └─ ← [Return]

```