### PR TITLE
Defender: Fix error in `proposeUpgrade` when project path has a space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.3 (2024-08-26)
+
+- Defender: Fix error in `proposeUpgrade` when project path has a space. ([#71](https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/pull/71))
+
 ## 0.3.2 (2024-08-14)
 
 - Fix simulation failure due to revert when upgrading deployments using OpenZeppelin Contracts v4. ([#65](https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/pull/65))

--- a/src/internal/DefenderDeploy.sol
+++ b/src/internal/DefenderDeploy.sol
@@ -265,7 +265,7 @@ library DefenderDeploy {
         inputBuilder[i++] = "--chainId";
         inputBuilder[i++] = Strings.toString(block.chainid);
         inputBuilder[i++] = "--contractArtifactFile";
-        inputBuilder[i++] = contractInfo.artifactPath;
+        inputBuilder[i++] = string(abi.encodePacked('"', contractInfo.artifactPath, '"'));
         if (proxyAdminAddress != address(0)) {
             inputBuilder[i++] = "--proxyAdminAddress";
             inputBuilder[i++] = vm.toString(proxyAdminAddress);

--- a/test/internal/DefenderDeploy.t.sol
+++ b/test/internal/DefenderDeploy.t.sol
@@ -311,9 +311,9 @@ contract DefenderDeployTest is Test {
             string.concat(
                 "npx @openzeppelin/defender-deploy-client-cli@",
                 Versions.DEFENDER_DEPLOY_CLIENT_CLI,
-                " proposeUpgrade --proxyAddress 0x1230000000000000000000000000000000000456 --newImplementationAddress 0x1110000000000000000000000000000000000222 --chainId 31337 --contractArtifactFile \"",
+                ' proposeUpgrade --proxyAddress 0x1230000000000000000000000000000000000456 --newImplementationAddress 0x1110000000000000000000000000000000000222 --chainId 31337 --contractArtifactFile "',
                 contractInfo.artifactPath,
-                "\""
+                '"'
             )
         );
     }

--- a/test/internal/DefenderDeploy.t.sol
+++ b/test/internal/DefenderDeploy.t.sol
@@ -311,8 +311,9 @@ contract DefenderDeployTest is Test {
             string.concat(
                 "npx @openzeppelin/defender-deploy-client-cli@",
                 Versions.DEFENDER_DEPLOY_CLIENT_CLI,
-                " proposeUpgrade --proxyAddress 0x1230000000000000000000000000000000000456 --newImplementationAddress 0x1110000000000000000000000000000000000222 --chainId 31337 --contractArtifactFile ",
-                contractInfo.artifactPath
+                " proposeUpgrade --proxyAddress 0x1230000000000000000000000000000000000456 --newImplementationAddress 0x1110000000000000000000000000000000000222 --chainId 31337 --contractArtifactFile \"",
+                contractInfo.artifactPath,
+                "\""
             )
         );
     }


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/issues/70