### PR TITLE
Defender: Add `metadata` option

### DIFF
--- a/docs/modules/api/pages/Options.adoc
+++ b/docs/modules/api/pages/Options.adoc
@@ -38,6 +38,7 @@ struct DefenderOptions {
   string licenseType;
   bool skipLicenseType;
   struct TxOverrides txOverrides;
+  string metadata;
 }
 ```
 

--- a/src/Options.sol
+++ b/src/Options.sol
@@ -89,6 +89,12 @@ struct DefenderOptions {
      * Transaction overrides for OpenZeppelin Defender deployments.
      */
     TxOverrides txOverrides;
+    /*
+     * When using OpenZeppelin Defender deployments, you can use this to identify, tag, or classify deployments.
+     * See https://docs.openzeppelin.com/defender/module/deploy#metadata.
+     * Must be a JSON string, for example: '{ "commitHash": "4ae3e0d", "tag": "v1.0.0", "anyOtherField": "anyValue" }'
+     */
+    string metadata;
 }
 
 /**

--- a/src/internal/DefenderDeploy.sol
+++ b/src/internal/DefenderDeploy.sol
@@ -117,6 +117,10 @@ library DefenderDeploy {
             inputBuilder[i++] = "--maxPriorityFeePerGas";
             inputBuilder[i++] = Strings.toString(defenderOpts.txOverrides.maxPriorityFeePerGas);
         }
+        if (!(defenderOpts.metadata).toSlice().empty()) {
+            inputBuilder[i++] = "--metadata";
+            inputBuilder[i++] = string(abi.encodePacked('"', vm.replace(defenderOpts.metadata, '"', '\\"'), '"'));
+        }
 
         // Create a copy of inputs but with the correct length
         string[] memory inputs = new string[](i);

--- a/test/internal/DefenderDeploy.t.sol
+++ b/test/internal/DefenderDeploy.t.sol
@@ -100,6 +100,7 @@ contract DefenderDeployTest is Test {
         opts.txOverrides.gasPrice = 1 gwei;
         opts.txOverrides.maxFeePerGas = 2 gwei;
         opts.txOverrides.maxPriorityFeePerGas = 0.5 gwei;
+        opts.metadata = '{ "commitHash": "4ae3e0d", "tag": "v1.0.0", "anyOtherField": "anyValue" }';
 
         string memory commandString = _toString(
             DefenderDeploy.buildDeployCommand(contractInfo, buildInfoFile, constructorData, opts)
@@ -112,7 +113,8 @@ contract DefenderDeployTest is Test {
                 Versions.DEFENDER_DEPLOY_CLIENT_CLI,
                 " deploy --contractName WithConstructor --contractPath test/contracts/WithConstructor.sol --chainId 31337 --buildInfoFile ",
                 buildInfoFile,
-                ' --constructorBytecode 0x000000000000000000000000000000000000000000000000000000000000007b --licenseType "My License Type" --relayerId my-relayer-id --salt 0xabc0000000000000000000000000000000000000000000000000000000000123 --gasLimit 100000 --gasPrice 1000000000 --maxFeePerGas 2000000000 --maxPriorityFeePerGas 500000000'
+                ' --constructorBytecode 0x000000000000000000000000000000000000000000000000000000000000007b --licenseType "My License Type" --relayerId my-relayer-id --salt 0xabc0000000000000000000000000000000000000000000000000000000000123 --gasLimit 100000 --gasPrice 1000000000 --maxFeePerGas 2000000000 --maxPriorityFeePerGas 500000000',
+                ' --metadata "{ \\"commitHash\\": \\"4ae3e0d\\", \\"tag\\": \\"v1.0.0\\", \\"anyOtherField\\": \\"anyValue\\" }"'
             )
         );
     }


### PR DESCRIPTION
Adds `metadata` option for Defender deployments in Foundry Upgrades.

Requires https://github.com/OpenZeppelin/defender-deploy-client-cli/pull/13

Part of https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/1076