### PR TITLE
Prepare for NPM publishing, update instructions for NPM and Soldeer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ broadcast/
 # Node modules
 node_modules/
 
+# NPM package files
+*.tgz
+
 # Hardhat build output
 artifacts/
 cache_hardhat/

--- a/README.md
+++ b/README.md
@@ -45,6 +45,31 @@ Set the following in `remappings.txt`:
 > **Note**
 > Use [LegacyUpgrades.sol](src/LegacyUpgrades.sol) instead of `Upgrades.sol` to upgrade existing deployments that were created with OpenZeppelin Contracts v4.
 
+### Optional: Alternative installation methods
+
+#### NPM
+
+Follow the steps above, but instead of running `forge install OpenZeppelin/openzeppelin-foundry-upgrades`, use this command instead:
+```
+npm install @openzeppelin/foundry-upgrades
+```
+
+Then add the following additional lines to `remappings.txt`, in addition to the ones described above:
+```
+openzeppelin-foundry-upgrades/=node_modules/@openzeppelin/foundry-upgrades/src/
+solidity-stringutils/=node_modules/@openzeppelin/foundry-upgrades/lib/solidity-stringutils/
+```
+
+#### Soldeer
+
+Follow the steps above, but instead of running `forge install OpenZeppelin/openzeppelin-foundry-upgrades`, use one of the install commands described in https://soldeer.xyz/project/openzeppelin-foundry-upgrades
+
+Then add the following additional lines to `remappings.txt`, in addition to the ones described above (replace `0.3.6` with the version of the plugin that you installed):
+```
+openzeppelin-foundry-upgrades/=dependencies/openzeppelin-foundry-upgrades-0.3.6/src/
+solidity-stringutils/=dependencies/openzeppelin-foundry-upgrades-0.3.6/lib/solidity-stringutils/
+```
+
 ## OpenZeppelin Defender integration
 
 See [DEFENDER.md](DEFENDER.md)

--- a/docs/modules/pages/foundry-upgrades.adoc
+++ b/docs/modules/pages/foundry-upgrades.adoc
@@ -49,6 +49,34 @@ Set the following in `remappings.txt`:
 
 NOTE: Use `LegacyUpgrades.sol` instead of `Upgrades.sol` to upgrade existing deployments that were created with OpenZeppelin Contracts v4.
 
+=== Optional: Alternative installation methods
+
+==== NPM
+
+Follow the steps above, but instead of running `forge install OpenZeppelin/openzeppelin-foundry-upgrades`, use this command instead:
+[source,console]
+----
+npm install @openzeppelin/foundry-upgrades
+----
+
+Then add the following additional lines to `remappings.txt`, in addition to the ones described above:
+[source,console]
+----
+openzeppelin-foundry-upgrades/=node_modules/@openzeppelin/foundry-upgrades/src/
+solidity-stringutils/=node_modules/@openzeppelin/foundry-upgrades/lib/solidity-stringutils/
+----
+
+==== Soldeer
+
+Follow the steps above, but instead of running `forge install OpenZeppelin/openzeppelin-foundry-upgrades`, use one of the install commands described in https://soldeer.xyz/project/openzeppelin-foundry-upgrades
+
+Then add the following additional lines to `remappings.txt`, in addition to the ones described above (replace `0.3.6` with the version of the plugin that you installed):
+[source,console]
+----
+openzeppelin-foundry-upgrades/=dependencies/openzeppelin-foundry-upgrades-0.3.6/src/
+solidity-stringutils/=dependencies/openzeppelin-foundry-upgrades-0.3.6/lib/solidity-stringutils/
+----
+
 == Foundry Requirements
 
 This library requires https://github.com/foundry-rs/forge-std[forge-std] version 1.8.0 or higher.

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "solhint-plugin-openzeppelin": "file:scripts/solhint-custom",
     "solidity-docgen": "^0.6.0-beta.36"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "@openzeppelin/defender-deploy-client-cli": "0.0.1-alpha.9",
     "@openzeppelin/upgrades-core": "^1.37.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,16 @@
 {
-  "name": "openzeppelin-foundry-upgrades",
-  "private": true,
+  "name": "@openzeppelin/foundry-upgrades",
+  "version": "0.4.0",
+  "description": "Foundry library for deploying and managing upgradeable contracts",
   "license": "MIT",
+  "files": [
+    "src/**/*",
+    "lib/solidity-stringutils/**/*"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades.git"
+  },
   "scripts": {
     "clean": "forge clean && hardhat clean",
     "compile": "forge build",
@@ -32,5 +41,9 @@
     "solhint": "^3.3.6",
     "solhint-plugin-openzeppelin": "file:scripts/solhint-custom",
     "solidity-docgen": "^0.6.0-beta.36"
+  },
+  "optionalDependencies": {
+    "@openzeppelin/defender-deploy-client-cli": "0.0.1-alpha.9",
+    "@openzeppelin/upgrades-core": "^1.37.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/foundry-upgrades",
-  "version": "0.4.0",
+  "version": "0.3.6",
   "description": "Foundry library for deploying and managing upgradeable contracts",
   "license": "MIT",
   "files": [


### PR DESCRIPTION
- Updates package.json for publishing to NPM
  - Sets `upgrades-core` and `defender-deploy-client-cli` as `peerDependencies`, since those are often run but not always required (for example if users do not run upgrade safety checks or Defender)
  - Updates the package name to `@openzeppelin/foundry-upgrades`
    - Users can use the package name as `@openzeppelin/foundry-upgrades` in their Solidity scripts/tests, but we leave the examples as `openzeppelin-foundry-upgrades` and use remappings to avoid confusion (since the same instructions are also used for Git submodules or Soldeer)
- Adds instructions for NPM and Soldeer installations
  - While OpenZeppelin Contracts (and Upgradeable Contracts) could also be installed with NPM or Soldeer, we omit that from the instructions to avoid further confusion, since the steps are already complex

Fixes #40 