### PR TITLE
Remove dependency on `solidity-stringutils`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
-[submodule "lib/solidity-stringutils"]
-	path = lib/solidity-stringutils
-	url = https://github.com/Arachnid/solidity-stringutils

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Remove dependency on `solidity-stringutils`. ([#91](https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/pull/91))
 
 ### Breaking changes
-- Requires forge-std version v1.9.5 or later.
+- Requires `forge-std` version v1.9.5 or higher.
 
 ## 0.3.8 (2025-01-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Remove dependency on `solidity-stringutils`.
+
 ## 0.3.7 (2025-01-13)
 
 - Update documentation links. ([#88](https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/pull/88))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
-## 0.3.9 (2025-01-27)
+## 0.4.0 (2025-01-27)
 
 - Remove dependency on `solidity-stringutils`. ([#91](https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/pull/91))
+
+### Breaking changes
+- Requires forge-std version v1.9.5 or later.
 
 ## 0.3.8 (2025-01-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.3.9 (2025-01-27)
 
 - Remove dependency on `solidity-stringutils`. ([#91](https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/pull/91))
 

--- a/README.md
+++ b/README.md
@@ -54,20 +54,18 @@ Follow the steps above, but instead of running `forge install OpenZeppelin/openz
 npm install @openzeppelin/foundry-upgrades
 ```
 
-Then add the following additional lines to `remappings.txt`, in addition to the ones described above:
+Then add the following additional line to `remappings.txt`, in addition to the ones described above:
 ```
 openzeppelin-foundry-upgrades/=node_modules/@openzeppelin/foundry-upgrades/src/
-solidity-stringutils/=node_modules/@openzeppelin/foundry-upgrades/lib/solidity-stringutils/
 ```
 
 #### Soldeer
 
 Follow the steps above, but instead of running `forge install OpenZeppelin/openzeppelin-foundry-upgrades`, use one of the install commands described in https://soldeer.xyz/project/openzeppelin-foundry-upgrades
 
-Then add the following additional lines to `remappings.txt`, in addition to the ones described above (replace `0.3.6` with the version of the plugin that you installed):
+Then add the following additional line to `remappings.txt`, in addition to the ones described above (replace `0.3.6` with the version of the plugin that you installed):
 ```
 openzeppelin-foundry-upgrades/=dependencies/openzeppelin-foundry-upgrades-0.3.6/src/
-solidity-stringutils/=dependencies/openzeppelin-foundry-upgrades-0.3.6/lib/solidity-stringutils/
 ```
 
 ## OpenZeppelin Defender integration
@@ -76,7 +74,7 @@ See [DEFENDER.md](DEFENDER.md)
 
 ## Foundry Requirements
 
-This library requires [forge-std](https://github.com/foundry-rs/forge-std) version 1.8.0 or higher.
+This library requires [forge-std](https://github.com/foundry-rs/forge-std) version 1.9.5 or higher.
 
 ## Before Running
 

--- a/docs/modules/pages/foundry-upgrades.adoc
+++ b/docs/modules/pages/foundry-upgrades.adoc
@@ -59,22 +59,20 @@ Follow the steps above, but instead of running `forge install OpenZeppelin/openz
 npm install @openzeppelin/foundry-upgrades
 ----
 
-Then add the following additional lines to `remappings.txt`, in addition to the ones described above:
+Then add the following additional line to `remappings.txt`, in addition to the ones described above:
 [source,console]
 ----
 openzeppelin-foundry-upgrades/=node_modules/@openzeppelin/foundry-upgrades/src/
-solidity-stringutils/=node_modules/@openzeppelin/foundry-upgrades/lib/solidity-stringutils/
 ----
 
 ==== Soldeer
 
 Follow the steps above, but instead of running `forge install OpenZeppelin/openzeppelin-foundry-upgrades`, use one of the install commands described in https://soldeer.xyz/project/openzeppelin-foundry-upgrades
 
-Then add the following additional lines to `remappings.txt`, in addition to the ones described above (replace `0.3.6` with the version of the plugin that you installed):
+Then add the following additional line to `remappings.txt`, in addition to the ones described above (replace `0.3.6` with the version of the plugin that you installed):
 [source,console]
 ----
 openzeppelin-foundry-upgrades/=dependencies/openzeppelin-foundry-upgrades-0.3.6/src/
-solidity-stringutils/=dependencies/openzeppelin-foundry-upgrades-0.3.6/lib/solidity-stringutils/
 ----
 
 == Foundry Requirements

--- a/docs/modules/pages/foundry-upgrades.adoc
+++ b/docs/modules/pages/foundry-upgrades.adoc
@@ -77,7 +77,7 @@ openzeppelin-foundry-upgrades/=dependencies/openzeppelin-foundry-upgrades-0.3.6/
 
 == Foundry Requirements
 
-This library requires https://github.com/foundry-rs/forge-std[forge-std] version 1.8.0 or higher.
+This library requires https://github.com/foundry-rs/forge-std[forge-std] version 1.9.5 or higher.
 
 == Before Running
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Foundry library for deploying and managing upgradeable contracts",
   "license": "MIT",
   "files": [
-    "src/**/*",
-    "lib/solidity-stringutils/**/*"
+    "src/**/*"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/foundry-upgrades",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "description": "Foundry library for deploying and managing upgradeable contracts",
   "license": "MIT",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/foundry-upgrades",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Foundry library for deploying and managing upgradeable contracts",
   "license": "MIT",
   "files": [

--- a/src/internal/Core.sol
+++ b/src/internal/Core.sol
@@ -377,7 +377,7 @@ library Core {
         string memory contractName,
         Options memory opts,
         bool requireReference
-    ) internal returns (string[] memory) {
+    ) internal view returns (string[] memory) {
         string memory outDir = Utils.getOutDir();
 
         string[] memory inputBuilder = new string[](2 ** 16);

--- a/src/internal/DefenderDeploy.sol
+++ b/src/internal/DefenderDeploy.sol
@@ -245,11 +245,8 @@ library DefenderDeploy {
                 );
             }
             string memory suffix = segments[1];
-            // Remove any following lines
-            if (vm.contains(suffix, "\n")) {
-                suffix = vm.split(suffix, "\n")[0];
-            }
-            return suffix;
+            // Keep only the first line
+            return vm.split(suffix, "\n")[0];
         } else if (required) {
             revert(
                 string(abi.encodePacked("Failed to find line with prefix '", expectedPrefix, "' in output: ", stdout))

--- a/src/internal/DefenderDeploy.sol
+++ b/src/internal/DefenderDeploy.sol
@@ -232,10 +232,19 @@ library DefenderDeploy {
         if (vm.contains(stdout, expectedPrefix)) {
             // Get the substring after the prefix
             string[] memory segments = vm.split(stdout, expectedPrefix);
-            string memory suffix = "";
-            for (uint256 i = 1; i < segments.length; i++) {
-                suffix = string(abi.encodePacked(suffix, segments[i]));
+            if (segments.length > 2) {
+                revert(
+                    string(
+                        abi.encodePacked(
+                            "Found multiple occurrences of prefix '",
+                            expectedPrefix,
+                            "' in output: ",
+                            stdout
+                        )
+                    )
+                );
             }
+            string memory suffix = segments[1];
             // Remove any following lines
             if (vm.contains(suffix, "\n")) {
                 suffix = vm.split(suffix, "\n")[0];

--- a/src/internal/DefenderDeploy.sol
+++ b/src/internal/DefenderDeploy.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.0;
 
 import {Vm} from "forge-std/Vm.sol";
 import {console} from "forge-std/console.sol";
-import {strings} from "solidity-stringutils/src/strings.sol";
 
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 
@@ -18,8 +17,6 @@ import {ProposeUpgradeResponse, ApprovalProcessResponse} from "../Defender.sol";
  * WARNING: DO NOT USE DIRECTLY. Use Defender.sol instead.
  */
 library DefenderDeploy {
-    using strings for *;
-
     function deploy(
         string memory contractName,
         bytes memory constructorData,
@@ -54,7 +51,7 @@ library DefenderDeploy {
     ) internal view returns (string[] memory) {
         Vm vm = Vm(Utils.CHEATCODE_ADDRESS);
 
-        if (!(defenderOpts.licenseType).toSlice().empty()) {
+        if (bytes(defenderOpts.licenseType).length != 0) {
             if (defenderOpts.skipVerifySourceCode) {
                 revert("The `licenseType` option cannot be used when the `skipVerifySourceCode` option is `true`");
             } else if (defenderOpts.skipLicenseType) {
@@ -86,14 +83,14 @@ library DefenderDeploy {
         if (defenderOpts.skipVerifySourceCode) {
             inputBuilder[i++] = "--verifySourceCode";
             inputBuilder[i++] = "false";
-        } else if (!(defenderOpts.licenseType).toSlice().empty()) {
+        } else if (bytes(defenderOpts.licenseType).length != 0) {
             inputBuilder[i++] = "--licenseType";
             inputBuilder[i++] = string(abi.encodePacked('"', defenderOpts.licenseType, '"'));
-        } else if (!defenderOpts.skipLicenseType && !(contractInfo.license).toSlice().empty()) {
+        } else if (!defenderOpts.skipLicenseType && bytes(contractInfo.license).length != 0) {
             inputBuilder[i++] = "--licenseType";
             inputBuilder[i++] = string(abi.encodePacked('"', _toLicenseType(contractInfo), '"'));
         }
-        if (!(defenderOpts.relayerId).toSlice().empty()) {
+        if (bytes(defenderOpts.relayerId).length != 0) {
             inputBuilder[i++] = "--relayerId";
             inputBuilder[i++] = defenderOpts.relayerId;
         }
@@ -117,7 +114,7 @@ library DefenderDeploy {
             inputBuilder[i++] = "--maxPriorityFeePerGas";
             inputBuilder[i++] = Strings.toString(defenderOpts.txOverrides.maxPriorityFeePerGas);
         }
-        if (!(defenderOpts.metadata).toSlice().empty()) {
+        if (bytes(defenderOpts.metadata).length != 0) {
             inputBuilder[i++] = "--metadata";
             inputBuilder[i++] = string(abi.encodePacked('"', vm.replace(defenderOpts.metadata, '"', '\\"'), '"'));
         }
@@ -133,35 +130,37 @@ library DefenderDeploy {
         return inputs;
     }
 
+    using Strings for string;
+
     function _toLicenseType(ContractInfo memory contractInfo) private pure returns (string memory) {
-        strings.slice memory id = contractInfo.license.toSlice();
-        if (id.equals("UNLICENSED".toSlice())) {
+        string memory id = contractInfo.license;
+        if (id.equal("UNLICENSED")) {
             return "None";
-        } else if (id.equals("Unlicense".toSlice())) {
+        } else if (id.equal("Unlicense")) {
             return "Unlicense";
-        } else if (id.equals("MIT".toSlice())) {
+        } else if (id.equal("MIT")) {
             return "MIT";
-        } else if (id.equals("GPL-2.0-only".toSlice()) || id.equals("GPL-2.0-or-later".toSlice())) {
+        } else if (id.equal("GPL-2.0-only") || id.equal("GPL-2.0-or-later")) {
             return "GNU GPLv2";
-        } else if (id.equals("GPL-3.0-only".toSlice()) || id.equals("GPL-3.0-or-later".toSlice())) {
+        } else if (id.equal("GPL-3.0-only") || id.equal("GPL-3.0-or-later")) {
             return "GNU GPLv3";
-        } else if (id.equals("LGPL-2.1-only".toSlice()) || id.equals("LGPL-2.1-or-later".toSlice())) {
+        } else if (id.equal("LGPL-2.1-only") || id.equal("LGPL-2.1-or-later")) {
             return "GNU LGPLv2.1";
-        } else if (id.equals("LGPL-3.0-only".toSlice()) || id.equals("LGPL-3.0-or-later".toSlice())) {
+        } else if (id.equal("LGPL-3.0-only") || id.equal("LGPL-3.0-or-later")) {
             return "GNU LGPLv3";
-        } else if (id.equals("BSD-2-Clause".toSlice())) {
+        } else if (id.equal("BSD-2-Clause")) {
             return "BSD-2-Clause";
-        } else if (id.equals("BSD-3-Clause".toSlice())) {
+        } else if (id.equal("BSD-3-Clause")) {
             return "BSD-3-Clause";
-        } else if (id.equals("MPL-2.0".toSlice())) {
+        } else if (id.equal("MPL-2.0")) {
             return "MPL-2.0";
-        } else if (id.equals("OSL-3.0".toSlice())) {
+        } else if (id.equal("OSL-3.0")) {
             return "OSL-3.0";
-        } else if (id.equals("Apache-2.0".toSlice())) {
+        } else if (id.equal("Apache-2.0")) {
             return "Apache-2.0";
-        } else if (id.equals("AGPL-3.0-only".toSlice()) || id.equals("AGPL-3.0-or-later".toSlice())) {
+        } else if (id.equal("AGPL-3.0-only") || id.equal("AGPL-3.0-or-later")) {
             return "GNU AGPLv3";
-        } else if (id.equals("BUSL-1.1".toSlice())) {
+        } else if (id.equal("BUSL-1.1")) {
             return "BSL 1.1";
         } else {
             revert(
@@ -217,7 +216,7 @@ library DefenderDeploy {
         return parseProposeUpgradeResponse(stdout);
     }
 
-    function parseProposeUpgradeResponse(string memory stdout) internal pure returns (ProposeUpgradeResponse memory) {
+    function parseProposeUpgradeResponse(string memory stdout) internal returns (ProposeUpgradeResponse memory) {
         ProposeUpgradeResponse memory response;
         response.proposalId = _parseLine("Proposal ID: ", stdout, true);
         response.url = _parseLine("Proposal URL: ", stdout, false);
@@ -228,15 +227,20 @@ library DefenderDeploy {
         string memory expectedPrefix,
         string memory stdout,
         bool required
-    ) private pure returns (string memory) {
-        strings.slice memory delim = expectedPrefix.toSlice();
-        if (stdout.toSlice().contains(delim)) {
-            strings.slice memory slice = stdout.toSlice().copy().find(delim).beyond(delim);
-            // Remove any following lines
-            if (slice.contains("\n".toSlice())) {
-                slice = slice.split("\n".toSlice());
+    ) private returns (string memory) {
+        Vm vm = Vm(Utils.CHEATCODE_ADDRESS);
+        if (vm.contains(stdout, expectedPrefix)) {
+            // Get the substring after the prefix
+            string[] memory segments = vm.split(stdout, expectedPrefix);
+            string memory suffix = "";
+            for (uint256 i = 1; i < segments.length; i++) {
+                suffix = string(abi.encodePacked(suffix, segments[i]));
             }
-            return slice.toString();
+            // Remove any following lines
+            if (vm.contains(suffix, "\n")) {
+                suffix = vm.split(suffix, "\n")[0];
+            }
+            return suffix;
         } else if (required) {
             revert(
                 string(abi.encodePacked("Failed to find line with prefix '", expectedPrefix, "' in output: ", stdout))
@@ -276,7 +280,7 @@ library DefenderDeploy {
             inputBuilder[i++] = "--proxyAdminAddress";
             inputBuilder[i++] = vm.toString(proxyAdminAddress);
         }
-        if (!(opts.defender.upgradeApprovalProcessId).toSlice().empty()) {
+        if (bytes(opts.defender.upgradeApprovalProcessId).length != 0) {
             inputBuilder[i++] = "--approvalProcessId";
             inputBuilder[i++] = opts.defender.upgradeApprovalProcessId;
         }
@@ -303,7 +307,7 @@ library DefenderDeploy {
         return parseApprovalProcessResponse(stdout);
     }
 
-    function parseApprovalProcessResponse(string memory stdout) internal pure returns (ApprovalProcessResponse memory) {
+    function parseApprovalProcessResponse(string memory stdout) internal returns (ApprovalProcessResponse memory) {
         Vm vm = Vm(Utils.CHEATCODE_ADDRESS);
 
         ApprovalProcessResponse memory response;
@@ -311,7 +315,7 @@ library DefenderDeploy {
         response.approvalProcessId = _parseLine("Approval process ID: ", stdout, true);
 
         string memory viaString = _parseLine("Via: ", stdout, false);
-        if (viaString.toSlice().len() != 0) {
+        if (bytes(viaString).length != 0) {
             response.via = vm.parseAddress(viaString);
         }
 

--- a/src/internal/StringFinder.sol
+++ b/src/internal/StringFinder.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Vm} from "forge-std/Vm.sol";
+import {Utils} from "./Utils.sol";
+
+/**
+ * String finder functions using Forge's string cheatcodes.
+ * For internal use only.
+ */
+library StringFinder {
+    /**
+     * Returns whether the subject string contains the search string.
+     */
+    function contains(string memory subject, string memory search) internal returns (bool) {
+        Vm vm = Vm(Utils.CHEATCODE_ADDRESS);
+        return vm.contains(subject, search);
+    }
+
+    /**
+     * Returns whether the subject string starts with the search string.
+     */
+    function startsWith(string memory subject, string memory search) internal pure returns (bool) {
+        Vm vm = Vm(Utils.CHEATCODE_ADDRESS);
+        uint256 index = vm.indexOf(subject, search);
+        return index == 0;
+    }
+
+    /**
+     * Returns whether the subject string ends with the search string.
+     */
+    function endsWith(string memory subject, string memory search) internal returns (bool) {
+        Vm vm = Vm(Utils.CHEATCODE_ADDRESS);
+        if (!vm.contains(subject, search)) {
+            return false;
+        }
+        string[] memory tokens = vm.split(subject, search);
+        return bytes(tokens[tokens.length - 1]).length == 0;
+    }
+
+    /**
+     * Returns the number of occurrences of the search string in the subject string.
+     */
+    function count(string memory subject, string memory search) internal returns (uint256) {
+        Vm vm = Vm(Utils.CHEATCODE_ADDRESS);
+        if (!vm.contains(subject, search)) {
+            return 0;
+        }
+        string[] memory tokens = vm.split(subject, search);
+        return tokens.length - 1;
+    }
+}

--- a/src/internal/StringFinder.sol
+++ b/src/internal/StringFinder.sol
@@ -29,23 +29,17 @@ library StringFinder {
     /**
      * Returns whether the subject string ends with the search string.
      */
-    function endsWith(string memory subject, string memory search) internal returns (bool) {
+    function endsWith(string memory subject, string memory search) internal pure returns (bool) {
         Vm vm = Vm(Utils.CHEATCODE_ADDRESS);
-        if (!vm.contains(subject, search)) {
-            return false;
-        }
         string[] memory tokens = vm.split(subject, search);
-        return bytes(tokens[tokens.length - 1]).length == 0;
+        return tokens.length > 1 && bytes(tokens[tokens.length - 1]).length == 0;
     }
 
     /**
-     * Returns the number of occurrences of the search string in the subject string.
+     * Returns the number of non-overlapping occurrences of the search string in the subject string.
      */
-    function count(string memory subject, string memory search) internal returns (uint256) {
+    function count(string memory subject, string memory search) internal pure returns (uint256) {
         Vm vm = Vm(Utils.CHEATCODE_ADDRESS);
-        if (!vm.contains(subject, search)) {
-            return 0;
-        }
         string[] memory tokens = vm.split(subject, search);
         return tokens.length - 1;
     }

--- a/src/internal/Utils.sol
+++ b/src/internal/Utils.sol
@@ -42,7 +42,10 @@ library Utils {
      * @param outDir Foundry output directory to search in if contractName is not an artifact path
      * @return Fully qualified name of the contract, e.g. "src/MyContract.sol:MyContract"
      */
-    function getFullyQualifiedName(string memory contractName, string memory outDir) internal returns (string memory) {
+    function getFullyQualifiedName(
+        string memory contractName,
+        string memory outDir
+    ) internal view returns (string memory) {
         ContractInfo memory info = getContractInfo(contractName, outDir);
         return string(abi.encodePacked(info.contractPath, ":", info.shortName));
     }
@@ -54,7 +57,10 @@ library Utils {
      * @param outDir Foundry output directory to search in if contractName is not an artifact path
      * @return ContractInfo struct containing information about the contract
      */
-    function getContractInfo(string memory contractName, string memory outDir) internal returns (ContractInfo memory) {
+    function getContractInfo(
+        string memory contractName,
+        string memory outDir
+    ) internal view returns (ContractInfo memory) {
         Vm vm = Vm(CHEATCODE_ADDRESS);
 
         ContractInfo memory info;
@@ -140,7 +146,7 @@ library Utils {
         return vm.envOr("FOUNDRY_OUT", defaultOutDir);
     }
 
-    function _toFileName(string memory name) private returns (string memory) {
+    function _toFileName(string memory name) private pure returns (string memory) {
         Vm vm = Vm(CHEATCODE_ADDRESS);
         if (name.endsWith(".sol")) {
             return name;
@@ -166,7 +172,7 @@ library Utils {
         }
     }
 
-    function _toShortName(string memory name) private returns (string memory) {
+    function _toShortName(string memory name) private pure returns (string memory) {
         Vm vm = Vm(CHEATCODE_ADDRESS);
         if (name.endsWith(".sol") && name.count(".sol") == 1) {
             return vm.replace(name, ".sol", "");

--- a/test-profiles/build-info-v2-bad/test/Upgrades.t.sol
+++ b/test-profiles/build-info-v2-bad/test/Upgrades.t.sol
@@ -4,12 +4,13 @@ pragma solidity ^0.8.20;
 import {Test} from "forge-std/Test.sol";
 
 import {Upgrades, Options} from "openzeppelin-foundry-upgrades/Upgrades.sol";
-import {strings} from "solidity-stringutils/src/strings.sol";
+
+import {StringFinder} from "openzeppelin-foundry-upgrades/internal/StringFinder.sol";
 
 import {MyContract} from "./contracts/MyContract.sol";
 
 contract UpgradesTest is Test {
-    using strings for *;
+    using StringFinder for string;
 
     function testValidateWithReferenceBuildInfo_Bad() public {
         Options memory opts;
@@ -19,8 +20,7 @@ contract UpgradesTest is Test {
         try v.validateUpgrade("MyContract.sol", opts) {
             fail();
         } catch Error(string memory reason) {
-            strings.slice memory slice = reason.toSlice();
-            assertTrue(slice.contains("Deleted `x`".toSlice()));
+            assertTrue(reason.contains("Deleted `x`"));
         }
     }
 }

--- a/test/Upgrades.t.sol
+++ b/test/Upgrades.t.sol
@@ -5,6 +5,8 @@ import {Test} from "forge-std/Test.sol";
 
 import {Upgrades, Options} from "openzeppelin-foundry-upgrades/Upgrades.sol";
 
+import {StringFinder} from "openzeppelin-foundry-upgrades/internal/StringFinder.sol";
+
 import {IBeacon} from "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import {ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
@@ -16,8 +18,6 @@ import {GreeterV2Proxiable} from "./contracts/GreeterV2Proxiable.sol";
 import {WithConstructor, NoInitializer} from "./contracts/WithConstructor.sol";
 import {HasOwner} from "./contracts/HasOwner.sol";
 
-import {strings} from "solidity-stringutils/src/strings.sol";
-
 // Import additional contracts to include them for compilation
 import "./contracts/Validations.sol";
 
@@ -25,7 +25,7 @@ import "./contracts/Validations.sol";
  * @dev Tests for the Upgrades library.
  */
 contract UpgradesTest is Test {
-    using strings for *;
+    using StringFinder for string;
 
     function testUUPS() public {
         address proxy = Upgrades.deployUUPSProxy(
@@ -281,9 +281,8 @@ contract UpgradesTest is Test {
         {
             fail();
         } catch Error(string memory reason) {
-            strings.slice memory slice = reason.toSlice();
-            assertTrue(slice.contains("`initialOwner` must not be a ProxyAdmin contract.".toSlice()));
-            assertTrue(slice.contains(vm.toString(address(admin)).toSlice()));
+            assertTrue(reason.contains("`initialOwner` must not be a ProxyAdmin contract."));
+            assertTrue(reason.contains(vm.toString(address(admin))));
         }
     }
 
@@ -302,9 +301,8 @@ contract UpgradesTest is Test {
         {
             fail();
         } catch Error(string memory reason) {
-            strings.slice memory slice = reason.toSlice();
-            assertTrue(slice.contains("`initialOwner` must not be a ProxyAdmin contract.".toSlice()));
-            assertTrue(slice.contains(vm.toString(address(hasOwner)).toSlice()));
+            assertTrue(reason.contains("`initialOwner` must not be a ProxyAdmin contract."));
+            assertTrue(reason.contains(vm.toString(address(hasOwner))));
         }
     }
 

--- a/test/UpgradesUseDefenderDeploy.t.sol
+++ b/test/UpgradesUseDefenderDeploy.t.sol
@@ -5,19 +5,19 @@ import {Test} from "forge-std/Test.sol";
 
 import {Upgrades, Options} from "openzeppelin-foundry-upgrades/Upgrades.sol";
 
+import {StringFinder} from "openzeppelin-foundry-upgrades/internal/StringFinder.sol";
+
 import {Greeter} from "./contracts/Greeter.sol";
 import {GreeterProxiable} from "./contracts/GreeterProxiable.sol";
 import {GreeterV2} from "./contracts/GreeterV2.sol";
 import {GreeterV2Proxiable} from "./contracts/GreeterV2Proxiable.sol";
-
-import {strings} from "solidity-stringutils/src/strings.sol";
 
 /**
  * @dev Tests that the `defender.useDefenderDeploy` flag is recognized in the Upgrades library.
  * These do not perform any actual deployments, but just checks that the Defender CLI is invoked and catches its error message since we are using a dev network.
  */
 contract UpgradesUseDefenderDeployTest is Test {
-    using strings for *;
+    using StringFinder for string;
 
     Deployer d;
 
@@ -25,11 +25,10 @@ contract UpgradesUseDefenderDeployTest is Test {
         d = new Deployer();
     }
 
-    function _assertDefenderNotAvailable(strings.slice memory slice) private pure {
+    function _assertDefenderNotAvailable(string memory str) private {
         assertTrue(
-            slice.contains(
-                "The current network with chainId 31337 is not supported by OpenZeppelin Defender".toSlice()
-            ) || slice.contains("DEFENDER_KEY and DEFENDER_SECRET must be set in environment variables".toSlice())
+            str.contains("The current network with chainId 31337 is not supported by OpenZeppelin Defender") ||
+                str.contains("DEFENDER_KEY and DEFENDER_SECRET must be set in environment variables")
         );
     }
 
@@ -46,9 +45,8 @@ contract UpgradesUseDefenderDeployTest is Test {
         {
             fail();
         } catch Error(string memory reason) {
-            strings.slice memory slice = reason.toSlice();
-            assertTrue(slice.contains("Failed to deploy contract GreeterProxiable.sol".toSlice()));
-            _assertDefenderNotAvailable(slice);
+            assertTrue(reason.contains("Failed to deploy contract GreeterProxiable.sol"));
+            _assertDefenderNotAvailable(reason);
         }
     }
 
@@ -66,9 +64,8 @@ contract UpgradesUseDefenderDeployTest is Test {
         {
             fail();
         } catch Error(string memory reason) {
-            strings.slice memory slice = reason.toSlice();
-            assertTrue(slice.contains("Failed to deploy contract Greeter.sol".toSlice()));
-            _assertDefenderNotAvailable(slice);
+            assertTrue(reason.contains("Failed to deploy contract Greeter.sol"));
+            _assertDefenderNotAvailable(reason);
         }
     }
 
@@ -86,9 +83,8 @@ contract UpgradesUseDefenderDeployTest is Test {
         {
             fail();
         } catch Error(string memory reason) {
-            strings.slice memory slice = reason.toSlice();
-            assertTrue(slice.contains("Failed to deploy contract GreeterV2Proxiable.sol".toSlice()));
-            _assertDefenderNotAvailable(slice);
+            assertTrue(reason.contains("Failed to deploy contract GreeterV2Proxiable.sol"));
+            _assertDefenderNotAvailable(reason);
         }
     }
 
@@ -99,9 +95,8 @@ contract UpgradesUseDefenderDeployTest is Test {
         try d.deployBeacon("Greeter.sol", msg.sender, opts) {
             fail();
         } catch Error(string memory reason) {
-            strings.slice memory slice = reason.toSlice();
-            assertTrue(slice.contains("Failed to deploy contract Greeter.sol".toSlice()));
-            _assertDefenderNotAvailable(slice);
+            assertTrue(reason.contains("Failed to deploy contract Greeter.sol"));
+            _assertDefenderNotAvailable(reason);
         }
     }
 
@@ -114,10 +109,9 @@ contract UpgradesUseDefenderDeployTest is Test {
         try d.deployBeaconProxy(beacon, abi.encodeCall(Greeter.initialize, (msg.sender, "hello")), opts) {
             fail();
         } catch Error(string memory reason) {
-            strings.slice memory slice = reason.toSlice();
             // Note the below is not the implementation contract, because this function only deploys the BeaconProxy contract
-            assertTrue(slice.contains("Failed to deploy contract BeaconProxy.sol".toSlice()));
-            _assertDefenderNotAvailable(slice);
+            assertTrue(reason.contains("Failed to deploy contract BeaconProxy.sol"));
+            _assertDefenderNotAvailable(reason);
         }
     }
 
@@ -130,9 +124,8 @@ contract UpgradesUseDefenderDeployTest is Test {
         try d.upgradeBeacon(beacon, "GreeterV2.sol", opts) {
             fail();
         } catch Error(string memory reason) {
-            strings.slice memory slice = reason.toSlice();
-            assertTrue(slice.contains("Failed to deploy contract GreeterV2.sol".toSlice()));
-            _assertDefenderNotAvailable(slice);
+            assertTrue(reason.contains("Failed to deploy contract GreeterV2.sol"));
+            _assertDefenderNotAvailable(reason);
         }
     }
 
@@ -143,9 +136,8 @@ contract UpgradesUseDefenderDeployTest is Test {
         try d.prepareUpgrade("GreeterV2.sol", opts) {
             fail();
         } catch Error(string memory reason) {
-            strings.slice memory slice = reason.toSlice();
-            assertTrue(slice.contains("Failed to deploy contract GreeterV2.sol".toSlice()));
-            _assertDefenderNotAvailable(slice);
+            assertTrue(reason.contains("Failed to deploy contract GreeterV2.sol"));
+            _assertDefenderNotAvailable(reason);
         }
     }
 

--- a/test/internal/Core.t.sol
+++ b/test/internal/Core.t.sol
@@ -42,7 +42,7 @@ contract CoreTest is Test {
         assertEq(Core.getUpgradeInterfaceVersion(address(u)), "");
     }
 
-    function testBuildValidateCommand() public {
+    function testBuildValidateCommand() public view {
         Options memory opts;
 
         string memory commandString = StringHelper.join(Core.buildValidateCommand("Greeter.sol", opts, false));
@@ -56,7 +56,7 @@ contract CoreTest is Test {
         );
     }
 
-    function testBuildValidateCommandExcludes() public {
+    function testBuildValidateCommandExcludes() public view {
         Options memory opts;
         opts.exclude = new string[](2);
         opts.exclude[0] = "test/contracts/**/{Foo,Bar}.sol";

--- a/test/internal/Core.t.sol
+++ b/test/internal/Core.t.sol
@@ -42,7 +42,7 @@ contract CoreTest is Test {
         assertEq(Core.getUpgradeInterfaceVersion(address(u)), "");
     }
 
-    function testBuildValidateCommand() public view {
+    function testBuildValidateCommand() public {
         Options memory opts;
 
         string memory commandString = StringHelper.join(Core.buildValidateCommand("Greeter.sol", opts, false));
@@ -56,7 +56,7 @@ contract CoreTest is Test {
         );
     }
 
-    function testBuildValidateCommandExcludes() public view {
+    function testBuildValidateCommandExcludes() public {
         Options memory opts;
         opts.exclude = new string[](2);
         opts.exclude[0] = "test/contracts/**/{Foo,Bar}.sol";

--- a/test/internal/DefenderDeploy.t.sol
+++ b/test/internal/DefenderDeploy.t.sol
@@ -287,7 +287,7 @@ contract DefenderDeployTest is Test {
         );
     }
 
-    function testBuildProposeUpgradeCommand() public {
+    function testBuildProposeUpgradeCommand() public view {
         ContractInfo memory contractInfo = Utils.getContractInfo("MyContractFile.sol:MyContractName", "out");
 
         Options memory opts;

--- a/test/internal/DefenderDeploy.t.sol
+++ b/test/internal/DefenderDeploy.t.sol
@@ -287,7 +287,7 @@ contract DefenderDeployTest is Test {
         );
     }
 
-    function testBuildProposeUpgradeCommand() public view {
+    function testBuildProposeUpgradeCommand() public {
         ContractInfo memory contractInfo = Utils.getContractInfo("MyContractFile.sol:MyContractName", "out");
 
         Options memory opts;
@@ -313,7 +313,7 @@ contract DefenderDeployTest is Test {
         );
     }
 
-    function testParseProposeUpgradeResponse() public pure {
+    function testParseProposeUpgradeResponse() public {
         string memory output = "Upgrade proposal created.\nProposal ID: 123\nProposal URL: https://my.url/my-tx";
 
         ProposeUpgradeResponse memory response = DefenderDeploy.parseProposeUpgradeResponse(output);
@@ -322,7 +322,7 @@ contract DefenderDeployTest is Test {
         assertEq(response.url, "https://my.url/my-tx");
     }
 
-    function testParseProposeUpgradeResponseNoUrl() public pure {
+    function testParseProposeUpgradeResponseNoUrl() public {
         string memory output = "Upgrade proposal created.\nProposal ID: 123";
 
         ProposeUpgradeResponse memory response = DefenderDeploy.parseProposeUpgradeResponse(output);
@@ -346,7 +346,7 @@ contract DefenderDeployTest is Test {
         );
     }
 
-    function testParseApprovalProcessResponse() public pure {
+    function testParseApprovalProcessResponse() public {
         string
             memory output = "Approval process ID: abc\nVia: 0x1230000000000000000000000000000000000456\nVia type: Relayer";
 
@@ -357,7 +357,7 @@ contract DefenderDeployTest is Test {
         assertEq(response.viaType, "Relayer");
     }
 
-    function testParseApprovalProcessResponseIdOnly() public pure {
+    function testParseApprovalProcessResponseIdOnly() public {
         string memory output = "Approval process ID: abc";
 
         ApprovalProcessResponse memory response = DefenderDeploy.parseApprovalProcessResponse(output);

--- a/test/internal/StringFinder.t.sol
+++ b/test/internal/StringFinder.t.sol
@@ -22,6 +22,10 @@ contract StringFinderTest is Test {
         assertTrue(str.startsWith("hello"));
         assertFalse(str.startsWith("ello"));
         assertFalse(str.startsWith("Hello"));
+        assertTrue(str.startsWith(""));
+
+        string memory empty = "";
+        assertFalse(empty.startsWith("a"));
     }
 
     function testEndsWith() public {
@@ -29,6 +33,10 @@ contract StringFinderTest is Test {
         assertTrue(str.endsWith("world"));
         assertFalse(str.endsWith("worl"));
         assertFalse(str.endsWith("World"));
+        assertTrue(str.endsWith(""));
+
+        string memory empty = "";
+        assertFalse(empty.endsWith("a"));
     }
 
     function testCount() public {
@@ -36,5 +44,13 @@ contract StringFinderTest is Test {
         assertEq(str.count("l"), 3);
         assertEq(str.count("ll"), 1);
         assertEq(str.count("a"), 0);
+        assertEq(str.count(""), 12);
+
+        string memory overlap = "aaa";
+        assertEq(overlap.count("aa"), 1); // does not count overlapping occurrences
+
+        string memory empty = "";
+        assertEq(empty.count("a"), 0);
+        assertEq(empty.count(""), 1);
     }
 }

--- a/test/internal/StringFinder.t.sol
+++ b/test/internal/StringFinder.t.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {StringFinder} from "openzeppelin-foundry-upgrades/internal/StringFinder.sol";
+
+/**
+ * @dev Tests the StringFinder internal library.
+ */
+contract StringFinderTest is Test {
+    using StringFinder for string;
+
+    function testContains() public {
+        string memory str = "hello world";
+        assertTrue(str.contains("ello"));
+        assertFalse(str.contains("Ello"));
+    }
+
+    function testStartsWith() public {
+        string memory str = "hello world";
+        assertTrue(str.startsWith("hello"));
+        assertFalse(str.startsWith("ello"));
+        assertFalse(str.startsWith("Hello"));
+    }
+
+    function testEndsWith() public {
+        string memory str = "hello world";
+        assertTrue(str.endsWith("world"));
+        assertFalse(str.endsWith("worl"));
+        assertFalse(str.endsWith("World"));
+    }
+
+    function testCount() public {
+        string memory str = "hello world";
+        assertEq(str.count("l"), 3);
+        assertEq(str.count("ll"), 1);
+        assertEq(str.count("a"), 0);
+    }
+}

--- a/test/internal/StringFinder.t.sol
+++ b/test/internal/StringFinder.t.sol
@@ -17,7 +17,7 @@ contract StringFinderTest is Test {
         assertFalse(str.contains("Ello"));
     }
 
-    function testStartsWith() public {
+    function testStartsWith() public pure {
         string memory str = "hello world";
         assertTrue(str.startsWith("hello"));
         assertFalse(str.startsWith("ello"));
@@ -28,7 +28,7 @@ contract StringFinderTest is Test {
         assertFalse(empty.startsWith("a"));
     }
 
-    function testEndsWith() public {
+    function testEndsWith() public pure {
         string memory str = "hello world";
         assertTrue(str.endsWith("world"));
         assertFalse(str.endsWith("worl"));
@@ -39,7 +39,7 @@ contract StringFinderTest is Test {
         assertFalse(empty.endsWith("a"));
     }
 
-    function testCount() public {
+    function testCount() public pure {
         string memory str = "hello world";
         assertEq(str.count("l"), 3);
         assertEq(str.count("ll"), 1);

--- a/test/internal/Utils.t.sol
+++ b/test/internal/Utils.t.sol
@@ -13,7 +13,7 @@ import {MyContractName} from "../contracts/MyContractFile.sol";
  * @dev Tests the Utils internal library.
  */
 contract UtilsTest is Test {
-    function testGetContractInfo_from_file() public {
+    function testGetContractInfo_from_file() public view {
         ContractInfo memory info = Utils.getContractInfo("Greeter.sol", "out");
 
         assertEq(info.shortName, "Greeter");
@@ -23,14 +23,14 @@ contract UtilsTest is Test {
         assertEq(info.sourceCodeHash, "0x9564e0245350d0eb5e42a8fed97d87518dbfbddf7668ed383f97a8558b2a9c39"); // source code hash of Greeter.sol
     }
 
-    function testGetContractInfo_from_fileAndName() public {
+    function testGetContractInfo_from_fileAndName() public view {
         ContractInfo memory info = Utils.getContractInfo("MyContractFile.sol:MyContractName", "out");
 
         assertEq(info.shortName, "MyContractName");
         assertEq(info.contractPath, "test/contracts/MyContractFile.sol");
     }
 
-    function testGetContractInfo_from_artifact() public {
+    function testGetContractInfo_from_artifact() public view {
         ContractInfo memory info = Utils.getContractInfo("out/MyContractFile.sol/MyContractName.json", "out");
 
         assertEq(info.shortName, "MyContractName");
@@ -49,7 +49,7 @@ contract UtilsTest is Test {
         }
     }
 
-    function testGetContractInfo_outDirTrailingSlash() public {
+    function testGetContractInfo_outDirTrailingSlash() public view {
         ContractInfo memory info = Utils.getContractInfo("Greeter.sol", "out/");
 
         assertEq(info.shortName, "Greeter");
@@ -63,19 +63,19 @@ contract UtilsTest is Test {
         } catch {}
     }
 
-    function testGetFullyQualifiedName_from_file() public {
+    function testGetFullyQualifiedName_from_file() public view {
         string memory fqName = Utils.getFullyQualifiedName("Greeter.sol", "out");
 
         assertEq(fqName, "test/contracts/Greeter.sol:Greeter");
     }
 
-    function testGetFullyQualifiedName_from_fileAndName() public {
+    function testGetFullyQualifiedName_from_fileAndName() public view {
         string memory fqName = Utils.getFullyQualifiedName("MyContractFile.sol:MyContractName", "out");
 
         assertEq(fqName, "test/contracts/MyContractFile.sol:MyContractName");
     }
 
-    function testGetFullyQualifiedName_from_artifact() public {
+    function testGetFullyQualifiedName_from_artifact() public view {
         string memory fqName = Utils.getFullyQualifiedName("out/MyContractFile.sol/MyContractName.json", "out");
 
         assertEq(fqName, "test/contracts/MyContractFile.sol:MyContractName");
@@ -134,11 +134,11 @@ contract UtilsTest is Test {
 }
 
 contract Invoker {
-    function getContractInfo(string memory contractName, string memory outDir) public {
+    function getContractInfo(string memory contractName, string memory outDir) public view {
         Utils.getContractInfo(contractName, outDir);
     }
 
-    function getFullyQualifiedName(string memory contractName, string memory outDir) public {
+    function getFullyQualifiedName(string memory contractName, string memory outDir) public view {
         Utils.getFullyQualifiedName(contractName, outDir);
     }
 }

--- a/test/internal/Utils.t.sol
+++ b/test/internal/Utils.t.sol
@@ -2,9 +2,10 @@
 pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";
-import {strings} from "solidity-stringutils/src/strings.sol";
 
 import {Utils, ContractInfo} from "openzeppelin-foundry-upgrades/internal/Utils.sol";
+
+import {StringFinder} from "openzeppelin-foundry-upgrades/internal/StringFinder.sol";
 
 import {MyContractName} from "../contracts/MyContractFile.sol";
 
@@ -12,7 +13,7 @@ import {MyContractName} from "../contracts/MyContractFile.sol";
  * @dev Tests the Utils internal library.
  */
 contract UtilsTest is Test {
-    function testGetContractInfo_from_file() public view {
+    function testGetContractInfo_from_file() public {
         ContractInfo memory info = Utils.getContractInfo("Greeter.sol", "out");
 
         assertEq(info.shortName, "Greeter");
@@ -22,14 +23,14 @@ contract UtilsTest is Test {
         assertEq(info.sourceCodeHash, "0x9564e0245350d0eb5e42a8fed97d87518dbfbddf7668ed383f97a8558b2a9c39"); // source code hash of Greeter.sol
     }
 
-    function testGetContractInfo_from_fileAndName() public view {
+    function testGetContractInfo_from_fileAndName() public {
         ContractInfo memory info = Utils.getContractInfo("MyContractFile.sol:MyContractName", "out");
 
         assertEq(info.shortName, "MyContractName");
         assertEq(info.contractPath, "test/contracts/MyContractFile.sol");
     }
 
-    function testGetContractInfo_from_artifact() public view {
+    function testGetContractInfo_from_artifact() public {
         ContractInfo memory info = Utils.getContractInfo("out/MyContractFile.sol/MyContractName.json", "out");
 
         assertEq(info.shortName, "MyContractName");
@@ -48,7 +49,7 @@ contract UtilsTest is Test {
         }
     }
 
-    function testGetContractInfo_outDirTrailingSlash() public view {
+    function testGetContractInfo_outDirTrailingSlash() public {
         ContractInfo memory info = Utils.getContractInfo("Greeter.sol", "out/");
 
         assertEq(info.shortName, "Greeter");
@@ -62,19 +63,19 @@ contract UtilsTest is Test {
         } catch {}
     }
 
-    function testGetFullyQualifiedName_from_file() public view {
+    function testGetFullyQualifiedName_from_file() public {
         string memory fqName = Utils.getFullyQualifiedName("Greeter.sol", "out");
 
         assertEq(fqName, "test/contracts/Greeter.sol:Greeter");
     }
 
-    function testGetFullyQualifiedName_from_fileAndName() public view {
+    function testGetFullyQualifiedName_from_fileAndName() public {
         string memory fqName = Utils.getFullyQualifiedName("MyContractFile.sol:MyContractName", "out");
 
         assertEq(fqName, "test/contracts/MyContractFile.sol:MyContractName");
     }
 
-    function testGetFullyQualifiedName_from_artifact() public view {
+    function testGetFullyQualifiedName_from_artifact() public {
         string memory fqName = Utils.getFullyQualifiedName("out/MyContractFile.sol/MyContractName.json", "out");
 
         assertEq(fqName, "test/contracts/MyContractFile.sol:MyContractName");
@@ -103,7 +104,7 @@ contract UtilsTest is Test {
         assertEq(Utils.getOutDir(), "out");
     }
 
-    using strings for *;
+    using StringFinder for string;
 
     function testGetBuildInfoFile() public {
         ContractInfo memory contractInfo = Utils.getContractInfo("Greeter.sol", "out");
@@ -113,8 +114,8 @@ contract UtilsTest is Test {
             "out"
         );
 
-        assertTrue(buildInfoFile.toSlice().startsWith("out/build-info".toSlice()));
-        assertTrue(buildInfoFile.toSlice().endsWith(".json".toSlice()));
+        assertTrue(buildInfoFile.startsWith("out/build-info"));
+        assertTrue(buildInfoFile.endsWith(".json"));
     }
 
     function testToBashCommand() public pure {
@@ -133,11 +134,11 @@ contract UtilsTest is Test {
 }
 
 contract Invoker {
-    function getContractInfo(string memory contractName, string memory outDir) public view {
+    function getContractInfo(string memory contractName, string memory outDir) public {
         Utils.getContractInfo(contractName, outDir);
     }
 
-    function getFullyQualifiedName(string memory contractName, string memory outDir) public view {
+    function getFullyQualifiedName(string memory contractName, string memory outDir) public {
         Utils.getFullyQualifiedName(contractName, outDir);
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -951,9 +951,9 @@
   integrity sha512-m4iHazOsOCv1DgM7eD7GupTJ+NFVujRZt1wzddDPSVGpWdKq1SKkla5htKG7+IS4d2XOCtzkUNwRZ7Vq5aEUMA==
 
 "@openzeppelin/contracts-upgradeable@^5.0.2":
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-5.0.2.tgz#3e5321a2ecdd0b206064356798c21225b6ec7105"
-  integrity sha512-0MmkHSHiW2NRFiT9/r5Lu4eJq5UJ4/tzlOgYXNAIj/ONkQTVnz22pLxDvp4C4uZ9he7ZFvGn3Driptn1/iU7tQ==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-5.2.0.tgz#caf9a6eaf4f16d7f90f9b45a6db4e7b125f4b13b"
+  integrity sha512-mZIu9oa4tQTlGiOJHk6D3LdJlqFqF6oNOSn6S6UVJtzfs9UsY9/dhMEbAVTwElxUtJnjpf6yA062+oBp+eOyPg==
 
 "@openzeppelin/contracts-v4@npm:@openzeppelin/contracts@^v4.9.6":
   version "4.9.6"
@@ -961,9 +961,9 @@
   integrity sha512-xSmezSupL+y9VkHZJGDoCBpmnB2ogM13ccaYDWqJTfS3dbuHkgjuwDFUmaFauBCboQMGB/S5UqUl2y54X99BmA==
 
 "@openzeppelin/contracts@^5.0.2":
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-5.0.2.tgz#b1d03075e49290d06570b2fd42154d76c2a5d210"
-  integrity sha512-ytPc6eLGcHHnapAZ9S+5qsdomhjo6QBHTDRRBFfTxXIpsicMhVPouPgmUPebZZZGX7vt9USA+Z+0M0dSVtSUEA==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-5.2.0.tgz#bd020694218202b811b0ea3eec07277814c658da"
+  integrity sha512-bxjNie5z89W1Ea0NZLZluFh8PrFNn9DH8DQlujEok2yjsOlraUPKID5p1Wk3qdNbf6XkQ1Os2RvfiHrrXLHWKA==
 
 "@openzeppelin/defender-deploy-client-cli@0.0.1-alpha.10":
   version "0.0.1-alpha.10"


### PR DESCRIPTION
- Remove dependency on `solidity-stringutils`. Instead, uses a combination of OpenZeppelin's Strings library, Forge's string cheatcodes, and an internal library for additional string finder functions.
- Sets the assembly block in `Core._deployFromBytecode` as `/// @solidity memory-safe-assembly`. This annotation is used instead of `assembly ("memory-safe")` so that it remains compatible with versions of Solidity used in both OpenZeppelin Contracts v4 and v5.

Fixes #89 