### PR TITLE
Fix error conditions when warnings occur in validation output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## Unreleased
+## 0.3.8 (2025-01-24)
 
-- Fix error conditions when warnings occur in validation output.
+- Fix error conditions when warnings occur in validation output. ([#94](https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/pull/94))
 
 ## 0.3.7 (2025-01-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix error conditions when warnings occur in validation output.
+
 ## 0.3.7 (2025-01-13)
 
 - Update documentation links. ([#88](https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/pull/88))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/foundry-upgrades",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Foundry library for deploying and managing upgradeable contracts",
   "license": "MIT",
   "files": [

--- a/test/Upgrades.t.sol
+++ b/test/Upgrades.t.sol
@@ -333,6 +333,19 @@ contract UpgradesTest is Test {
             opts
         );
     }
+
+    function testWarningAndError() public {
+        Options memory opts;
+        opts.unsafeAllow = "state-variable-immutable";
+
+        Invoker i = new Invoker();
+        try i.validateImplementation("Validations.sol:HasWarningAndError", opts) {
+            fail();
+        } catch Error(string memory reason) {
+            strings.slice memory slice = reason.toSlice();
+            assertTrue(slice.contains("Use of delegatecall is not allowed".toSlice()));
+        }
+    }
 }
 
 contract Invoker {

--- a/test/contracts/Validations.sol
+++ b/test/contracts/Validations.sol
@@ -79,3 +79,12 @@ contract NamespacedV2_UpgradesFrom_Ok {
         uint256 c;
     }
 }
+
+contract HasWarningAndError {
+    uint256 immutable x = 1; // allow `state-variable-immutable` using option to turn into a warning
+
+    function unsafe() public {
+        (bool s, ) = msg.sender.delegatecall("");
+        s;
+    }
+}


### PR DESCRIPTION
When running validations via upgrades core CLI:
- success is indicated by exit code 0 and "SUCCESS"
- failures are indicated by exit code 1 and "FAILURE"
- warnings are written to `stderr`.  This is intentional, and allows the warnings to be separate from validation results output (which has extraneous information such as which contracts passed, which we want to ignore if validations succeded)

Previously, if exit code was 1 (validations failed) and there is content in `stderr`, we would revert with `stderr` as the reason.  This is misleading because `stderr` only contains the warnings, and not the actual validation results.

Instead, we should log all warnings (from `stderr`) if the CLI finished with `stdout` containing "SUCCESS" or "FAILURE", and then report validation results appropriately.

If `stdout` not have "SUCCESS" or "FAILURE", this indicates a problem with running the CLI itself.

Fixes https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/issues/83
Fixes https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/1117