### PR TITLE
Add dispatch action to trigger updating docs on openzeppelin-upgrades on doc updates

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -90,4 +90,4 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${{ secrets.OZ_UPGRADE_TRIGGER_TOKEN }}" \
             https://api.github.com/repos/CoveMB/openzeppelin-upgrades/dispatches \
-            -d '{"event_type":"update-foundry-submodule"}'
+            -d '{"event_type":"update-foundry-submodule-docs"}'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,6 +6,7 @@ on:
   pull_request: {}
   workflow_dispatch: {}
 
+
 env:
   FOUNDRY_PROFILE: ci
 
@@ -65,3 +66,14 @@ jobs:
         run: |
           yarn test
         id: test
+
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger repository_dispatch
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN_OZ_UPGRADE_TRIGGER }}" \
+            https://api.github.com/repos/CoveMB/openzeppelin-upgrades/dispatches \
+            -d '{"event_type":"custom-event","client_payload":{"key":"value"}}'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -69,8 +69,8 @@ jobs:
 
   dispatch:
     runs-on: ubuntu-latest
-    # needs: [lint, docs, tests]
-    # if: success()
+    needs: [lint, docs, tests]
+    if: success()
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -69,11 +69,13 @@ jobs:
 
   dispatch:
     runs-on: ubuntu-latest
+    # needs: [lint, docs, tests]
+    # if: success()
     steps:
       - name: Trigger repository_dispatch
         run: |
           curl -X POST \
             -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Authorization: token ${{ secrets.OZ_UPGRADE_TRIGGER_TOKEN }}" \
             https://api.github.com/repos/CoveMB/openzeppelin-upgrades/dispatches \
             -d '{"event_type":"custom-event","client_payload":{"key":"value"}}'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -72,7 +72,21 @@ jobs:
     # needs: [lint, docs, tests]
     # if: success()
     steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Check for changes in the `docs/` folder
+        id: check_changes
+        run: |
+          git fetch origin main
+          CHANGED_FILES=$(git diff --name-only HEAD^ HEAD -- docs/)
+          if [ -n "$CHANGED_FILES" ]; then
+            echo "SHOULD_TRIGGER_DOC_UPDATE=true" >> $GITHUB_ENV
+          fi
+
       - name: Trigger repository_dispatch
+        if: env.SHOULD_TRIGGER_DOC_UPDATE == 'true'
         run: |
           curl -X POST \
             -H "Accept: application/vnd.github.v3+json" \

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -81,7 +81,7 @@ jobs:
         id: check_changes
         run: |
           git fetch origin main
-          [ -n "$(git diff --name-only origin/main -- docs/)" ] && echo "SHOULD_TRIGGER_DOC_UPDATE=true" >> $GITHUB_ENV || true
+          [ -n "$(git diff --name-only HEAD^ HEAD -- docs/)" ] && echo "SHOULD_TRIGGER_DOC_UPDATE=true" >> $GITHUB_ENV || true
 
       - name: Trigger repository_dispatch
         if: env.SHOULD_TRIGGER_DOC_UPDATE == 'true'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -93,4 +93,4 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${{ secrets.OZ_UPGRADE_TRIGGER_TOKEN }}" \
             https://api.github.com/repos/CoveMB/openzeppelin-upgrades/dispatches \
-            -d '{"event_type":"custom-event","client_payload":{"key":"value"}}'
+            -d '{"event_type":"update-foundry-submodule"}'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -89,5 +89,5 @@ jobs:
           curl -X POST \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${{ secrets.OZ_UPGRADE_TRIGGER_TOKEN }}" \
-            https://api.github.com/repos/CoveMB/openzeppelin-upgrades/dispatches \
+            https://api.github.com/repos/OpenZeppelin/openzeppelin-upgrades/dispatches \
             -d '{"event_type":"update-foundry-submodule-docs"}'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -81,10 +81,7 @@ jobs:
         id: check_changes
         run: |
           git fetch origin main
-          CHANGED_FILES=$(git diff --name-only HEAD^ HEAD -- docs/)
-          if [ -n "$CHANGED_FILES" ]; then
-            echo "SHOULD_TRIGGER_DOC_UPDATE=true" >> $GITHUB_ENV
-          fi
+          [ -n "$(git diff --name-only origin/main -- docs/)" ] && echo "SHOULD_TRIGGER_DOC_UPDATE=true" >> $GITHUB_ENV
 
       - name: Trigger repository_dispatch
         if: env.SHOULD_TRIGGER_DOC_UPDATE == 'true'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -75,6 +75,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-depth: 2
 
       - name: Check for changes in the `docs/` folder
         id: check_changes

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -74,6 +74,6 @@ jobs:
         run: |
           curl -X POST \
             -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN_OZ_UPGRADE_TRIGGER }}" \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             https://api.github.com/repos/CoveMB/openzeppelin-upgrades/dispatches \
             -d '{"event_type":"custom-event","client_payload":{"key":"value"}}'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -81,7 +81,7 @@ jobs:
         id: check_changes
         run: |
           git fetch origin main
-          [ -n "$(git diff --name-only origin/main -- docs/)" ] && echo "SHOULD_TRIGGER_DOC_UPDATE=true" >> $GITHUB_ENV
+          [ -n "$(git diff --name-only origin/main -- docs/)" ] && echo "SHOULD_TRIGGER_DOC_UPDATE=true" >> $GITHUB_ENV || true
 
       - name: Trigger repository_dispatch
         if: env.SHOULD_TRIGGER_DOC_UPDATE == 'true'

--- a/docs/modules/api/pages/api-foundry-upgrades.adoc
+++ b/docs/modules/api/pages/api-foundry-upgrades.adoc
@@ -2,8 +2,6 @@
 
 == Contract name formats
 
-changes
-
 Contract names must be provided in specific formats depending on context. The following are the required formats for each context:
 
 === Foundry artifact format

--- a/docs/modules/api/pages/api-foundry-upgrades.adoc
+++ b/docs/modules/api/pages/api-foundry-upgrades.adoc
@@ -10,7 +10,7 @@ Contexts:
 
 * `contractName` parameter
 * `referenceContract` option if `referenceBuildInfoDir` option is not set
-* annotation
+* annotation 2
 
 Can be in any of the following forms according to Foundry's https://book.getfoundry.sh/cheatcodes/get-code[getCode] cheatcode:
 

--- a/docs/modules/api/pages/api-foundry-upgrades.adoc
+++ b/docs/modules/api/pages/api-foundry-upgrades.adoc
@@ -10,7 +10,7 @@ Contexts:
 
 * `contractName` parameter
 * `referenceContract` option if `referenceBuildInfoDir` option is not set
-* `tmp` to remove
+* `tmp` to remove after
 
 Can be in any of the following forms according to Foundry's https://book.getfoundry.sh/cheatcodes/get-code[getCode] cheatcode:
 

--- a/docs/modules/api/pages/api-foundry-upgrades.adoc
+++ b/docs/modules/api/pages/api-foundry-upgrades.adoc
@@ -1,5 +1,5 @@
 = OpenZeppelin Foundry Upgrades API
-CHANGE
+
 == Contract name formats
 
 Contract names must be provided in specific formats depending on context. The following are the required formats for each context:

--- a/docs/modules/api/pages/api-foundry-upgrades.adoc
+++ b/docs/modules/api/pages/api-foundry-upgrades.adoc
@@ -10,7 +10,7 @@ Contexts:
 
 * `contractName` parameter
 * `referenceContract` option if `referenceBuildInfoDir` option is not set
-* `tmp` to remove
+* `tmp` to remove again
 
 Can be in any of the following forms according to Foundry's https://book.getfoundry.sh/cheatcodes/get-code[getCode] cheatcode:
 

--- a/docs/modules/api/pages/api-foundry-upgrades.adoc
+++ b/docs/modules/api/pages/api-foundry-upgrades.adoc
@@ -1,4 +1,4 @@
-= OpenZeppelin Foundry Upgrades API TMP
+= OpenZeppelin Foundry Upgrades API
 
 == Contract name formats
 
@@ -10,6 +10,7 @@ Contexts:
 
 * `contractName` parameter
 * `referenceContract` option if `referenceBuildInfoDir` option is not set
+* `tmp` to remove
 
 Can be in any of the following forms according to Foundry's https://book.getfoundry.sh/cheatcodes/get-code[getCode] cheatcode:
 

--- a/docs/modules/api/pages/api-foundry-upgrades.adoc
+++ b/docs/modules/api/pages/api-foundry-upgrades.adoc
@@ -8,9 +8,8 @@ Contract names must be provided in specific formats depending on context. The fo
 
 Contexts:
 
-* `contractName` parameter
+* `contractName` parameter tmp
 * `referenceContract` option if `referenceBuildInfoDir` option is not set
-* `tmp` to be removed
 
 Can be in any of the following forms according to Foundry's https://book.getfoundry.sh/cheatcodes/get-code[getCode] cheatcode:
 

--- a/docs/modules/api/pages/api-foundry-upgrades.adoc
+++ b/docs/modules/api/pages/api-foundry-upgrades.adoc
@@ -10,7 +10,7 @@ Contexts:
 
 * `contractName` parameter
 * `referenceContract` option if `referenceBuildInfoDir` option is not set
-* annotation 2
+* annotation 1
 
 Can be in any of the following forms according to Foundry's https://book.getfoundry.sh/cheatcodes/get-code[getCode] cheatcode:
 

--- a/docs/modules/api/pages/api-foundry-upgrades.adoc
+++ b/docs/modules/api/pages/api-foundry-upgrades.adoc
@@ -1,5 +1,5 @@
 = OpenZeppelin Foundry Upgrades API
-
+CHANGE
 == Contract name formats
 
 Contract names must be provided in specific formats depending on context. The following are the required formats for each context:

--- a/docs/modules/api/pages/api-foundry-upgrades.adoc
+++ b/docs/modules/api/pages/api-foundry-upgrades.adoc
@@ -10,7 +10,7 @@ Contexts:
 
 * `contractName` parameter
 * `referenceContract` option if `referenceBuildInfoDir` option is not set
-* `tmp` to remove after
+* `tmp` to remove
 
 Can be in any of the following forms according to Foundry's https://book.getfoundry.sh/cheatcodes/get-code[getCode] cheatcode:
 

--- a/docs/modules/api/pages/api-foundry-upgrades.adoc
+++ b/docs/modules/api/pages/api-foundry-upgrades.adoc
@@ -2,6 +2,8 @@
 
 == Contract name formats
 
+changes
+
 Contract names must be provided in specific formats depending on context. The following are the required formats for each context:
 
 === Foundry artifact format

--- a/docs/modules/api/pages/api-foundry-upgrades.adoc
+++ b/docs/modules/api/pages/api-foundry-upgrades.adoc
@@ -1,4 +1,4 @@
-= OpenZeppelin Foundry Upgrades API
+= OpenZeppelin Foundry Upgrades API TMP
 
 == Contract name formats
 
@@ -8,7 +8,7 @@ Contract names must be provided in specific formats depending on context. The fo
 
 Contexts:
 
-* `contractName` parameter tmp
+* `contractName` parameter
 * `referenceContract` option if `referenceBuildInfoDir` option is not set
 
 Can be in any of the following forms according to Foundry's https://book.getfoundry.sh/cheatcodes/get-code[getCode] cheatcode:

--- a/docs/modules/api/pages/api-foundry-upgrades.adoc
+++ b/docs/modules/api/pages/api-foundry-upgrades.adoc
@@ -10,6 +10,7 @@ Contexts:
 
 * `contractName` parameter
 * `referenceContract` option if `referenceBuildInfoDir` option is not set
+* annotation
 
 Can be in any of the following forms according to Foundry's https://book.getfoundry.sh/cheatcodes/get-code[getCode] cheatcode:
 

--- a/docs/modules/api/pages/api-foundry-upgrades.adoc
+++ b/docs/modules/api/pages/api-foundry-upgrades.adoc
@@ -10,7 +10,6 @@ Contexts:
 
 * `contractName` parameter
 * `referenceContract` option if `referenceBuildInfoDir` option is not set
-* `tmp` to remove again
 
 Can be in any of the following forms according to Foundry's https://book.getfoundry.sh/cheatcodes/get-code[getCode] cheatcode:
 

--- a/docs/modules/api/pages/api-foundry-upgrades.adoc
+++ b/docs/modules/api/pages/api-foundry-upgrades.adoc
@@ -10,7 +10,7 @@ Contexts:
 
 * `contractName` parameter
 * `referenceContract` option if `referenceBuildInfoDir` option is not set
-* annotation 1
+* `tmp` to be removed
 
 Can be in any of the following forms according to Foundry's https://book.getfoundry.sh/cheatcodes/get-code[getCode] cheatcode:
 


### PR DESCRIPTION
On main branch if lint, docs and tests succeeded checks if there has been changes in in the docs folder from previous commit.
If there's been changes triggers the `update-foundry-submodule-docs` workflow on `OpenZeppelin/openzeppelin-upgrades`

## To Do
Create token with following capabilities on `OpenZeppelin/openzeppelin-upgrades`:
- Actions: read and write
- Contents: read and write