### PR TITLE
Fix import reference on coverage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Upgrades.upgradeBeacon(beacon, "MyContractV2.sol");
 To enable code coverage reports with `forge coverage`, use the following deployment pattern in your tests: instantiate your implementation contracts directly and use the `UnsafeUpgrades` library. For example:
 ```solidity
 address implementation = address(new MyContract());
-address proxy = Upgrades.deployUUPSProxy(
+address proxy = UnsafeUpgrades.deployUUPSProxy(
     implementation,
     abi.encodeCall(MyContract.initialize, ("arguments for the initialize function"))
 );


### PR DESCRIPTION
When trying to integrate Foundry with upgradeable contracts, I observed that the example code describing how to integrate this tooling with Foundry's coverage tooling references the wrong import - it should use `UnsafeUpgrades`, not `Upgrades`.