### PR TITLE
fix: prevent error when match returns null

### DIFF
--- a/docs/templates/helpers.js
+++ b/docs/templates/helpers.js
@@ -38,8 +38,7 @@ function getAllLinks(items) {
 module.exports['with-prelude'] = opts => {
   const links = getAllLinks(opts.data.site.items);
   const contents = opts.fn();
-  const neededLinks = contents
-    .match(/\{[-._a-z0-9]+\}/gi)
+  const neededLinks = (contents.match(/\{[-._a-z0-9]+\}/gi) || [])
     .map(m => m.replace(/^\{(.+)\}$/, '$1'))
     .filter(k => k in links);
   const prelude = neededLinks.map(k => `:${k}: ${links[k]}`).join('\n');


### PR DESCRIPTION
I noticed that if `match` doesn’t find any matches, it returns `null`, which causes an error when calling `.map()`.
This is now fixed by adding a fallback to an empty array.