### PR TITLE
Update incorrect contract name for using `referenceBuildInfoDir`

### DIFF
--- a/docs/modules/pages/foundry-upgrades.adoc
+++ b/docs/modules/pages/foundry-upgrades.adoc
@@ -246,9 +246,9 @@ TIP: If possible, keep the old version of the implementation contract's source c
 ----
 Options memory opts;
 opts.referenceBuildInfoDir = "/old-builds/build-info-v1";
-opts.referenceContract = "build-info-v1:MyContract";
-Upgrades.upgradeProxy(proxy, "MyContract.sol", "", opts);
-// or Upgrades.upgradeBeacon(beacon, "MyContract.sol", opts);
+opts.referenceContract = "build-info-v1:MyContractV1.sol";
+Upgrades.upgradeProxy(proxy, "MyContractV2.sol", "", opts);
+// or Upgrades.upgradeBeacon(beacon, "MyContractV2.sol", opts);
 ----
 
 == Coverage Testing


### PR DESCRIPTION
I believe there might be an error in this page.

In the first example, the contract name ends in `.sol` + there is the V1 in `referenceContract` and V2 passed as parameter to the `upgradeProxy` function.

In the second example, no `.sol` is provided and the `upgradeProxy` function use as parameter what seems to be the old implementation contract name (passed as `opts.referenceContract = "build-info-v1:MyContract"`.

I might be wrong but this seems odd to me.

<img width="776" alt="image" src="https://github.com/user-attachments/assets/2ca36041-5d48-4c7f-a1d2-bc19773c591c" />
