### PR TITLE
docs: clarify Defender Deploy Environment API keys

### DIFF
--- a/docs/modules/pages/foundry-defender.adoc
+++ b/docs/modules/pages/foundry-defender.adoc
@@ -34,6 +34,8 @@ DEFENDER_KEY=<Your API key>
 DEFENDER_SECRET=<Your API secret>
 ----
 
+NOTE: These API keys are specifically for the Deploy Environment (Production or Test) that you configured in Defender. You can obtain these keys from the Deploy module in Defender during the environment setup process. For more information, see https://docs.openzeppelin.com/defender/v2/tutorial/deploy#environment_setup.
+
 == Network Selection
 
 The network that is used with OpenZeppelin Defender is determined by the network that Foundry is connected to.

--- a/docs/modules/pages/foundry-defender.adoc
+++ b/docs/modules/pages/foundry-defender.adoc
@@ -34,7 +34,7 @@ DEFENDER_KEY=<Your API key>
 DEFENDER_SECRET=<Your API secret>
 ----
 
-NOTE: These API keys are specifically for the Deploy Environment (Production or Test) that you configured in Defender. You can obtain these keys from the Deploy module in Defender during the environment setup process. For more information, see https://docs.openzeppelin.com/defender/v2/tutorial/deploy#environment_setup.
+NOTE: The API key for the above must at least have the capability to Manage Deployments. You can configure your API keys at https://defender.openzeppelin.com/#/settings/api-keys.
 
 == Network Selection
 

--- a/docs/modules/pages/foundry-defender.adoc
+++ b/docs/modules/pages/foundry-defender.adoc
@@ -34,7 +34,7 @@ DEFENDER_KEY=<Your API key>
 DEFENDER_SECRET=<Your API secret>
 ----
 
-NOTE: The API key for the above must at least have the capability to Manage Deployments. You can configure your API keys at https://defender.openzeppelin.com/#/settings/api-keys.
+NOTE: The API key for the above must at least have the capability to Manage Deployments (optionally Manage Relayers is needed to create an approval process with a Relayer). You can configure your API keys at https://defender.openzeppelin.com/#/settings/api-keys.
 
 == Network Selection
 


### PR DESCRIPTION
## Description

This PR addresses the issue described in OpenZeppelin/openzeppelin-upgrades#996 by clarifying that the API keys referenced in the Defender integration documentation are specifically from the Production or Test Deploy Environment configured in Defender.

### Changes made:
- Added a note to `foundry-defender.adoc` explaining that the API keys are specifically from the Deploy Environment
- Added a link to the Defender documentation's environment setup section for more information

### Fixes
- Closes OpenZeppelin/openzeppelin-upgrades#996 (via auto-generation)

### Motivation
Users were unclear about which API keys to use for Defender integration. This change makes it explicit that the keys should come from the Deploy Environment in Defender, reducing confusion and improving the developer experience.