### PR TITLE
Move link to Defender integration doc

### DIFF
--- a/docs/modules/pages/foundry-defender.adoc
+++ b/docs/modules/pages/foundry-defender.adoc
@@ -1,4 +1,4 @@
-= OpenZeppelin Defender integration
+= OpenZeppelin Defender with Foundry
 
 OpenZeppelin Foundry Upgrades can be used for performing deployments through https://docs.openzeppelin.com/defender/[OpenZeppelin Defender], which allows for features such as gas pricing estimation, resubmissions, and automated bytecode and source code verification.
 

--- a/docs/modules/pages/foundry-upgrades.adoc
+++ b/docs/modules/pages/foundry-upgrades.adoc
@@ -272,6 +272,10 @@ IMPORTANT: Include the `--sender <ADDRESS>` flag for the `forge script` command 
 
 NOTE: Include the `--verify` flag for the `forge script` command if you want to verify source code such as on Etherscan. This will verify your implementation contracts along with any proxy contracts as part of the deployment.
 
+== Defender
+
+If you are using OpenZeppelin Defender, see xref:foundry-defender.adoc[OpenZeppelin Defender with Foundry] for how to use it for deployments.
+
 == API
 
 See xref:api-foundry-upgrades.adoc[Foundry Upgrades API] for the full API documentation.

--- a/docs/modules/pages/foundry-upgrades.adoc
+++ b/docs/modules/pages/foundry-upgrades.adoc
@@ -272,7 +272,7 @@ IMPORTANT: Include the `--sender <ADDRESS>` flag for the `forge script` command 
 
 NOTE: Include the `--verify` flag for the `forge script` command if you want to verify source code such as on Etherscan. This will verify your implementation contracts along with any proxy contracts as part of the deployment.
 
-== Defender
+== Usage with Defender
 
 If you are using OpenZeppelin Defender, see xref:foundry-defender.adoc[OpenZeppelin Defender with Foundry] for how to use it for deployments.
 


### PR DESCRIPTION
Moves the Defender integration doc to a subsection under the Foundry plugin doc page.